### PR TITLE
Add Metal repeat_kv_heads kernel for GQA

### DIFF
--- a/src/Metallic/kernels/mod.rs
+++ b/src/Metallic/kernels/mod.rs
@@ -1,7 +1,7 @@
 use crate::metallic::{
-    Context, MetalError, Operation, Tensor,
     encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_compute_pipeline_state},
     resource_cache::ResourceCache,
+    Context, MetalError, Operation, Tensor,
 };
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
@@ -24,6 +24,7 @@ pub mod kv_rearrange;
 pub mod layernorm;
 pub mod matmul;
 pub mod permute;
+pub mod repeat_kv_heads;
 pub mod rmsnorm;
 pub mod rope;
 pub mod scaled_dot_product_attention;
@@ -43,6 +44,7 @@ pub enum KernelLibrary {
     KvRearrange,
     LayerNorm,
     Permute,
+    RepeatKvHeads,
     Rope,
     RMSNorm,
     Silu,
@@ -61,6 +63,7 @@ impl KernelLibrary {
             KernelLibrary::KvRearrange => include_str!("kv_rearrange/kernel.metal"),
             KernelLibrary::LayerNorm => include_str!("layernorm/kernel.metal"),
             KernelLibrary::Permute => include_str!("permute/kernel.metal"),
+            KernelLibrary::RepeatKvHeads => include_str!("repeat_kv_heads/kernel.metal"),
             KernelLibrary::Rope => include_str!("rope/kernel.metal"),
             KernelLibrary::RMSNorm => include_str!("rmsnorm/kernel.metal"),
             KernelLibrary::Silu => include_str!("silu/kernel.metal"),
@@ -82,6 +85,7 @@ pub enum KernelFunction {
     KvRearrange,
     LayerNorm,
     Permute,
+    RepeatKvHeads,
     Rope,
     RMSNorm,
     Silu,
@@ -102,6 +106,7 @@ impl KernelFunction {
             KernelFunction::KvRearrange => KernelLibrary::KvRearrange,
             KernelFunction::LayerNorm => KernelLibrary::LayerNorm,
             KernelFunction::Permute => KernelLibrary::Permute,
+            KernelFunction::RepeatKvHeads => KernelLibrary::RepeatKvHeads,
             KernelFunction::Rope => KernelLibrary::Rope,
             KernelFunction::RMSNorm => KernelLibrary::RMSNorm,
             KernelFunction::Silu => KernelLibrary::Silu,
@@ -121,6 +126,7 @@ impl KernelFunction {
             KernelFunction::KvRearrange => "kv_rearrange_kernel",
             KernelFunction::LayerNorm => "layernorm_kernel",
             KernelFunction::Permute => "permute_kernel",
+            KernelFunction::RepeatKvHeads => "repeat_kv_heads_kernel",
             KernelFunction::Rope => "rope_kernel",
             KernelFunction::RMSNorm => "rmsnorm_kernel",
             KernelFunction::Silu => "silu_kernel",

--- a/src/Metallic/kernels/repeat_kv_heads/kernel.metal
+++ b/src/Metallic/kernels/repeat_kv_heads/kernel.metal
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void repeat_kv_heads_kernel(device const float* input [[buffer(0)]],
+                                   device float* output [[buffer(1)]],
+                                   constant uint& group_size [[buffer(2)]],
+                                   constant uint& batch [[buffer(3)]],
+                                   constant uint& n_kv_heads [[buffer(4)]],
+                                   constant uint& n_heads [[buffer(5)]],
+                                   constant uint& seq [[buffer(6)]],
+                                   constant uint& head_dim [[buffer(7)]],
+                                   constant uint& total_elements [[buffer(8)]],
+                                   uint gid [[thread_position_in_grid]]) {
+    if (gid >= total_elements) {
+        return;
+    }
+
+    uint dim_idx = gid % head_dim;
+    uint tmp = gid / head_dim;
+    uint seq_idx = tmp % seq;
+    uint batch_head_idx = tmp / seq;
+
+    uint b = batch_head_idx / n_heads;
+    uint h = batch_head_idx % n_heads;
+    uint kv_head = h / group_size;
+
+    uint input_batch_head = b * n_kv_heads + kv_head;
+    uint input_index = ((input_batch_head * seq) + seq_idx) * head_dim + dim_idx;
+
+    output[gid] = input[input_index];
+}

--- a/src/Metallic/kernels/repeat_kv_heads/mod.rs
+++ b/src/Metallic/kernels/repeat_kv_heads/mod.rs
@@ -1,0 +1,130 @@
+use super::*;
+
+pub struct RepeatKvHeadsOp;
+
+struct RepeatKvHeads {
+    input: Tensor,
+    output: Tensor,
+    group_size: u32,
+    batch: u32,
+    n_kv_heads: u32,
+    n_heads: u32,
+    seq: u32,
+    head_dim: u32,
+    total_elements: u32,
+    pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+}
+
+impl KernelInvocable for RepeatKvHeadsOp {
+    type Args = (Tensor, u32, u32, u32, u32, u32, u32);
+
+    fn function_id() -> Option<KernelFunction> {
+        Some(KernelFunction::RepeatKvHeads)
+    }
+
+    fn new(
+        ctx: &mut Context,
+        args: Self::Args,
+        pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
+        _cache: Option<&mut ResourceCache>,
+    ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
+        let (mut input, group_size, batch, n_kv_heads, n_heads, seq, head_dim) = args;
+
+        if group_size == 0 {
+            return Err(MetalError::InvalidShape(
+                "group_size for repeat_kv_heads must be greater than zero".to_string(),
+            ));
+        }
+        if n_heads == 0 || n_kv_heads == 0 {
+            return Err(MetalError::InvalidShape(
+                "Head counts for repeat_kv_heads must be greater than zero".to_string(),
+            ));
+        }
+        if n_heads % n_kv_heads != 0 {
+            return Err(MetalError::InvalidShape(format!(
+                "n_heads ({}) must be a multiple of n_kv_heads ({})",
+                n_heads, n_kv_heads
+            )));
+        }
+        if group_size != n_heads / n_kv_heads {
+            return Err(MetalError::InvalidShape(format!(
+                "group_size ({}) must equal n_heads / n_kv_heads ({})",
+                group_size,
+                n_heads / n_kv_heads
+            )));
+        }
+
+        let input_dims = input.dims();
+        if input_dims.len() != 3
+            || input_dims[0] != (batch * n_kv_heads) as usize
+            || input_dims[1] != seq as usize
+            || input_dims[2] != head_dim as usize
+        {
+            return Err(MetalError::InvalidShape(format!(
+                "Input dims {:?} must be [batch*n_kv_heads, seq, head_dim]",
+                input_dims
+            )));
+        }
+
+        ctx.prepare_tensors_for_active_cmd(&mut [&mut input]);
+
+        let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];
+        let output = Tensor::create_tensor_pooled(output_dims, ctx)?;
+        let total_elements = output.len() as u32;
+
+        let op = RepeatKvHeads {
+            input,
+            output: output.clone(),
+            group_size,
+            batch,
+            n_kv_heads,
+            n_heads,
+            seq,
+            head_dim,
+            total_elements,
+            pipeline: pipeline.expect("Kernel Library supplied for MetalKernels"),
+        };
+
+        Ok((Box::new(op), output))
+    }
+}
+
+impl Operation for RepeatKvHeads {
+    fn encode(
+        &self,
+        command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+        _cache: &mut ResourceCache,
+    ) -> Result<(), MetalError> {
+        let encoder = command_buffer
+            .computeCommandEncoder()
+            .ok_or(MetalError::ComputeEncoderCreationFailed)?;
+
+        let threads_per_tg = MTLSize {
+            width: 256,
+            height: 1,
+            depth: 1,
+        };
+        let groups = MTLSize {
+            width: self.total_elements.div_ceil(256) as usize,
+            height: 1,
+            depth: 1,
+        };
+
+        set_compute_pipeline_state(&encoder, &self.pipeline);
+        set_buffer(&encoder, 0, &self.input.buf, self.input.offset);
+        set_buffer(&encoder, 1, &self.output.buf, self.output.offset);
+        set_bytes(&encoder, 2, &self.group_size);
+        set_bytes(&encoder, 3, &self.batch);
+        set_bytes(&encoder, 4, &self.n_kv_heads);
+        set_bytes(&encoder, 5, &self.n_heads);
+        set_bytes(&encoder, 6, &self.seq);
+        set_bytes(&encoder, 7, &self.head_dim);
+        set_bytes(&encoder, 8, &self.total_elements);
+
+        dispatch_threadgroups(&encoder, groups, threads_per_tg);
+        encoder.endEncoding();
+        Ok(())
+    }
+}
+
+mod repeat_kv_heads_test;

--- a/src/Metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
+++ b/src/Metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
@@ -1,0 +1,68 @@
+#![cfg(test)]
+
+use super::*;
+
+fn cpu_repeat_kv_heads(
+    input: &[f32],
+    group_size: usize,
+    batch: usize,
+    n_kv_heads: usize,
+    n_heads: usize,
+    seq: usize,
+    head_dim: usize,
+) -> Vec<f32> {
+    let mut output = vec![0.0f32; batch * n_heads * seq * head_dim];
+    for b in 0..batch {
+        for h_kv in 0..n_kv_heads {
+            let input_offset_base = ((b * n_kv_heads + h_kv) * seq) * head_dim;
+            for g in 0..group_size {
+                let h = h_kv * group_size + g;
+                let output_offset_base = ((b * n_heads + h) * seq) * head_dim;
+                for s in 0..seq {
+                    let input_offset = input_offset_base + s * head_dim;
+                    let output_offset = output_offset_base + s * head_dim;
+                    output[output_offset..output_offset + head_dim].copy_from_slice(&input[input_offset..input_offset + head_dim]);
+                }
+            }
+        }
+    }
+    output
+}
+
+#[test]
+fn test_repeat_kv_heads_kernel_matches_cpu() -> Result<(), MetalError> {
+    let mut ctx = Context::new()?;
+
+    let batch = 2usize;
+    let n_kv_heads = 2usize;
+    let group_size = 3usize;
+    let n_heads = n_kv_heads * group_size;
+    let seq = 4usize;
+    let head_dim = 5usize;
+
+    let element_count = batch * n_kv_heads * seq * head_dim;
+    let input_data: Vec<f32> = (0..element_count).map(|v| v as f32).collect();
+    let input = Tensor::create_tensor_from_slice(&input_data, vec![batch * n_kv_heads, seq, head_dim], &ctx)?;
+
+    let expected = cpu_repeat_kv_heads(&input_data, group_size, batch, n_kv_heads, n_heads, seq, head_dim);
+
+    let output = ctx.call::<RepeatKvHeadsOp>((
+        input,
+        group_size as u32,
+        batch as u32,
+        n_kv_heads as u32,
+        n_heads as u32,
+        seq as u32,
+        head_dim as u32,
+    ))?;
+    ctx.synchronize();
+
+    assert_eq!(output.dims(), &[batch * n_heads, seq, head_dim]);
+    let gpu_values = output.as_slice();
+    assert_eq!(gpu_values.len(), expected.len());
+    for (idx, (gpu, cpu)) in gpu_values.iter().zip(expected.iter()).enumerate() {
+        assert!((gpu - cpu).abs() < 1e-5, "Mismatch at index {}: gpu={} expected={}", idx, gpu, cpu);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a repeat_kv_heads Metal kernel module and register it with the kernel manager
- expose RepeatKvHeadsOp so Qwen25::repeat_kv_heads can issue the copy on the active GPU command buffer
- add unit and forward-step tests to cover GPU/CPU parity and latency instrumentation for the kv_repeat phase

## Testing
- not run (Metal support unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8b05c1f4883268a4d4bdd5c7bd4d4