### PR TITLE
Implement fused QKV projection pipeline

### DIFF
--- a/docs/ATTN_QKV_OPTIMIZATION.md
+++ b/docs/ATTN_QKV_OPTIMIZATION.md
@@ -1,0 +1,46 @@
+# attn_qkv_proj Optimization Notes
+
+This document summarizes actionable strategies to reduce the latency and memory footprint of the `attn_qkv_proj` phase recorded by our instrumentation during autoregressive decoding.
+
+## Current Hot Path
+
+During `forward_step` each transformer block currently issues three independent GEMMs followed by bias adds to produce Q, K, and V projections before head packing and RoPE:
+
+* `ctx.matmul` is called once per projection with `transpose_b = true`.
+* A `BroadcastElemwiseAddOp` adds the bias tensor for each projection.
+* Each tensor is subsequently rearranged into per-head layouts for attention.
+
+Because these operations run back-to-back they occupy the same latency band that our metrics report as **attn_qkv_proj**.
+
+## Optimization Opportunities
+
+### 1. Fuse the QKV projection into a single dispatch
+
+* Concatenate the Q/K/V weights along the output dimension and pre-bake the matching biases so that we can issue **one** `ctx.matmul` and **one** fused bias add (or a custom kernel that performs both). This removes two command-buffer submissions and two bias kernels per block.
+* Packing the fused weights upfront also reduces repeated reads from Metal buffers, aligning with the synchronization model that keeps work inside a single command buffer until the host touches results.【F:TENSOR_SYNC.md†L3-L25】【F:src/Metallic/models/qwen25/mod.rs†L379-L394】
+* If we introduce a dedicated Metal kernel for `linear_bias_fused` we can record only one `LatencyEvent::block_phase` for the entire projection, improving profiling clarity while avoiding CPU fallbacks that would break batching.【F:TENSOR_SYNC.md†L13-L25】【F:INSTRUMENTATION.md†L5-L28】
+
+### 2. Store weights in the optimal layout
+
+* The matmul currently requests a transpose of every projection weight (`transpose_b = true`). Persisting the weights in column-major/row-major form that matches Metal's preferred orientation eliminates the runtime transpose branch and allows us to call `ctx.matmul` without the transpose flag.【F:src/Metallic/models/qwen25/mod.rs†L385-L392】
+* Re-exporting checkpoints with pre-transposed weights trades a one-time conversion for per-token savings, honoring our performance-first rule set.【F:PROJECT_RULES.md†L3-L23】
+
+### 3. Batch bias and reshape work on GPU
+
+* `BroadcastElemwiseAddOp` launches separate compute passes that can stall if they trigger host-visible tensors. Extending the fused linear kernel to output `[batch, seq, 3 * head_dim]` and then slicing/views for Q/K/V keeps all work on-GPU and leverages the implicit synchronization pipeline.【F:TENSOR_SYNC.md†L3-L25】【F:src/Metallic/models/qwen25/mod.rs†L384-L404】
+* After fusion, adjust `KvRearrangeOp` (or replace it with a kernel that directly emits `[heads, head_dim]` tiles) so that we avoid redundant tensor reshapes or CPU-driven loops flagged as remaining sync pain points.【F:TENSOR_SYNC.md†L13-L24】【F:src/Metallic/models/qwen25/mod.rs†L402-L429】
+
+### 4. Instrument and validate each change
+
+* Use the existing latency collectors to confirm the **attn_qkv_proj** row shrinks after each optimization. Capturing before/after snapshots in Ratatui or JSONL logs keeps regressions visible.【F:INSTRUMENTATION.md†L5-L58】
+* Pair measurements with targeted micro-benchmarks (e.g., a criterion bench around the fused projection) so we can iterate without waiting for full-model runs. Ensure any new kernel obeys the implicit synchronization contract to prevent unexpected host waits.【F:TENSOR_SYNC.md†L3-L30】【F:INSTRUMENTATION.md†L5-L58】
+
+## Next Steps
+
+1. Prototype a fused `linear_bias_fused` operation in Metal, including weight packing tooling when loading GGUF weights.
+2. Update the Qwen25 block to consume the fused tensor and slice Q/K/V views before RoPE.
+3. Validate with the metrics dashboard and ask a teammate to benchmark on-device since we cannot execute Metal workloads inside CI.
+
+The fused projection now ships as `Context::fused_qkv_projection`, which emits separate Q/K/V tensors via the Metal kernel in `kernels/fused_qkv`. Weight packing happens during GGUF load so runtime matmuls no longer require transposed operands.【F:src/Metallic/context.rs†L205-L299】【F:src/Metallic/models/qwen25/loading.rs†L77-L358】
+
+Following these steps should turn **attn_qkv_proj** from the second-slowest phase into a smaller slice of the block latency budget while maintaining clean layering and synchronization safety.

--- a/src/Metallic/kernels/fused_qkv/kernel.metal
+++ b/src/Metallic/kernels/fused_qkv/kernel.metal
@@ -1,0 +1,38 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void fused_qkv_bias_split(
+    device const float* qkv_linear [[buffer(0)]],
+    device const float* bias [[buffer(1)]],
+    device float* q_out [[buffer(2)]],
+    device float* k_out [[buffer(3)]],
+    device float* v_out [[buffer(4)]],
+    constant uint& rows [[buffer(5)]],
+    constant uint& q_cols [[buffer(6)]],
+    constant uint& kv_cols [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total_cols = q_cols + 2 * kv_cols;
+    uint total = rows * total_cols;
+    if (gid >= total) {
+        return;
+    }
+
+    uint row = gid / total_cols;
+    uint col = gid % total_cols;
+
+    float value = qkv_linear[gid] + bias[col];
+
+    if (col < q_cols) {
+        uint out_idx = row * q_cols + col;
+        q_out[out_idx] = value;
+    } else if (col < q_cols + kv_cols) {
+        uint offset = col - q_cols;
+        uint out_idx = row * kv_cols + offset;
+        k_out[out_idx] = value;
+    } else {
+        uint offset = col - q_cols - kv_cols;
+        uint out_idx = row * kv_cols + offset;
+        v_out[out_idx] = value;
+    }
+}

--- a/src/Metallic/kernels/fused_qkv/mod.rs
+++ b/src/Metallic/kernels/fused_qkv/mod.rs
@@ -1,0 +1,16 @@
+//! Metal kernels for fused QKV projection post-processing.
+
+// The compute pipeline is consumed directly from `Context::fused_qkv_projection`.
+// This module exists to keep the directory structure consistent with other kernels.
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+
+    #[test]
+    fn kernel_symbol_exists() {
+        // Ensure the Metal source is included during compilation by touching the library enum.
+        let name = KernelFunction::FusedQkvBiasSplit.name();
+        assert_eq!(name, "fused_qkv_bias_split");
+    }
+}

--- a/src/Metallic/kernels/mod.rs
+++ b/src/Metallic/kernels/mod.rs
@@ -19,6 +19,7 @@ pub mod elemwise_add;
 pub mod elemwise_div;
 pub mod elemwise_mul;
 pub mod elemwise_sub;
+pub mod fused_qkv;
 pub mod gelu;
 pub mod kv_rearrange;
 pub mod layernorm;
@@ -40,6 +41,7 @@ pub enum KernelLibrary {
     ElemwiseDiv,
     ElemwiseMul,
     ElemwiseSub,
+    FusedQkv,
     Gelu,
     KvRearrange,
     LayerNorm,
@@ -59,6 +61,7 @@ impl KernelLibrary {
             KernelLibrary::ElemwiseDiv => include_str!("elemwise_div/kernel.metal"),
             KernelLibrary::ElemwiseMul => include_str!("elemwise_mul/kernel.metal"),
             KernelLibrary::ElemwiseSub => include_str!("elemwise_sub/kernel.metal"),
+            KernelLibrary::FusedQkv => include_str!("fused_qkv/kernel.metal"),
             KernelLibrary::Gelu => include_str!("gelu/kernel.metal"),
             KernelLibrary::KvRearrange => include_str!("kv_rearrange/kernel.metal"),
             KernelLibrary::LayerNorm => include_str!("layernorm/kernel.metal"),
@@ -81,6 +84,7 @@ pub enum KernelFunction {
     ElemwiseDiv,
     ElemwiseMul,
     ElemwiseSub,
+    FusedQkvBiasSplit,
     Gelu,
     KvRearrange,
     LayerNorm,
@@ -122,6 +126,7 @@ impl KernelFunction {
             KernelFunction::ElemwiseDiv => "div_kernel",
             KernelFunction::ElemwiseMul => "mul_kernel",
             KernelFunction::ElemwiseSub => "sub_kernel",
+            KernelFunction::FusedQkvBiasSplit => "fused_qkv_bias_split",
             KernelFunction::Gelu => "gelu_kernel",
             KernelFunction::KvRearrange => "kv_rearrange_kernel",
             KernelFunction::LayerNorm => "layernorm_kernel",

--- a/src/Metallic/kernels/mod.rs
+++ b/src/Metallic/kernels/mod.rs
@@ -106,6 +106,7 @@ impl KernelFunction {
             KernelFunction::ElemwiseDiv => KernelLibrary::ElemwiseDiv,
             KernelFunction::ElemwiseMul => KernelLibrary::ElemwiseMul,
             KernelFunction::ElemwiseSub => KernelLibrary::ElemwiseSub,
+            KernelFunction::FusedQkvBiasSplit => KernelLibrary::FusedQkv,
             KernelFunction::Gelu => KernelLibrary::Gelu,
             KernelFunction::KvRearrange => KernelLibrary::KvRearrange,
             KernelFunction::LayerNorm => KernelLibrary::LayerNorm,

--- a/src/Metallic/models/qwen25/loading.rs
+++ b/src/Metallic/models/qwen25/loading.rs
@@ -87,11 +87,12 @@ fn copy_weight_transposed_into_fused(
     dst: &mut crate::metallic::Tensor,
     dst_col_offset: usize,
 ) -> Result<(), MetalError> {
+    let dst_dims = dst.dims().to_vec();
     pack_weight_transposed_into_fused_slice(
         src.as_slice(),
         src.dims(),
         dst.as_mut_slice(),
-        dst.dims(),
+        &dst_dims,
         dst_col_offset,
     )
 }

--- a/src/Metallic/models/qwen25/qwen25_tests.rs
+++ b/src/Metallic/models/qwen25/qwen25_tests.rs
@@ -218,7 +218,7 @@ fn test_forward_step_records_kv_repeat_phase() -> Result<(), MetalError> {
     let mut model = Qwen25::new(cfg, &mut ctx)?;
 
     let block = &model.blocks[0];
-    let kv_dim = block.attn_k_weight.dims()[0];
+    let kv_dim = block.kv_dim;
     let kv_head_dim = kv_dim / model.config.n_kv_heads;
     let batch_heads = 1 * model.config.n_kv_heads;
     for layer_idx in 0..model.config.n_layers {


### PR DESCRIPTION
## Summary
- add a fused Metal kernel plus `Context::fused_qkv_projection` to emit Q/K/V in one dispatch
- pack Q/K/V weights and biases into fused tensors during GGUF loading and update the Qwen25 forward paths
- refresh metrics, tests, and docs to reflect the new fused attn_qkv_proj implementation

## Testing
- not run (Metal execution unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8b37fc124832696404b252d1f5f20