### PR TITLE
Refactor KV cache layout for Qwen25 attention

### DIFF
--- a/src/Metallic/kernels/repeat_kv_heads/kernel.metal
+++ b/src/Metallic/kernels/repeat_kv_heads/kernel.metal
@@ -9,7 +9,8 @@ kernel void repeat_kv_heads_kernel(device const float* input [[buffer(0)]],
                                    constant uint& n_heads [[buffer(5)]],
                                    constant uint& seq [[buffer(6)]],
                                    constant uint& head_dim [[buffer(7)]],
-                                   constant uint& total_elements [[buffer(8)]],
+                                   constant uint& cache_stride [[buffer(8)]],
+                                   constant uint& total_elements [[buffer(9)]],
                                    uint gid [[thread_position_in_grid]]) {
     if (gid >= total_elements) {
         return;
@@ -25,7 +26,7 @@ kernel void repeat_kv_heads_kernel(device const float* input [[buffer(0)]],
     uint kv_head = h / group_size;
 
     uint input_batch_head = b * n_kv_heads + kv_head;
-    uint input_index = ((input_batch_head * seq) + seq_idx) * head_dim + dim_idx;
+    uint input_index = ((input_batch_head * cache_stride) + seq_idx) * head_dim + dim_idx;
 
     output[gid] = input[input_index];
 }

--- a/src/Metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
+++ b/src/Metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
@@ -54,6 +54,7 @@ fn test_repeat_kv_heads_kernel_matches_cpu() -> Result<(), MetalError> {
         n_heads as u32,
         seq as u32,
         head_dim as u32,
+        seq as u32,
     ))?;
     ctx.synchronize();
 


### PR DESCRIPTION
## Summary
- allocate layer KV caches in [batch_heads, seq_len, head_dim] order and update write_kv_step to stream per-head slices without permuting
- expose a stride-aware kv_cache_history_view and plumb the new CacheHistory object through Qwen25 to repeat/reuse caches without Tensor::permute
- extend repeat_kv_heads to accept the cache stride, update the Metal kernel accordingly, and refresh unit tests for the new layout

## Testing
- cargo check *(fails: objc2 crate requires an Apple target in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d943614ac483268b4a4094414cabed