### PR TITLE
Size KV caches per generation

### DIFF
--- a/INSTRUMENTATION.md
+++ b/INSTRUMENTATION.md
@@ -39,9 +39,11 @@ Incremental generation reuses the repeated buffers directly, so the
 append instead of replaying the full history via the `RepeatKvHeads` kernel.
 This ensures the dashboard continues to show a stable `kv_repeat` duration
 even though the underlying work is now amortized. The dedicated KV cache pool
-now reserves a higher ceiling (8 GB) to account for the additional repeated
-buffers; the memory collector reports the combined canonical + repeated usage
-per layer so large prompts remain debuggable.
+still has an 8 GB safety limit, but generation now sizes each allocation to the
+active prompt window (`prompt_tokens + max_new_tokens`, clamped to the model's
+maximum). The memory collector reports the combined canonical + repeated usage
+per layer using this per-run capacity so the UI mirrors the smaller footprint
+instead of the legacy full-sequence reservation.
 
 ### Softmax backend benchmarking
 

--- a/src/Metallic/generation.rs
+++ b/src/Metallic/generation.rs
@@ -255,6 +255,7 @@ where
     let kv_dim = d_model * n_kv_heads / n_heads;
     let kv_head_dim = kv_dim / n_kv_heads;
     let batch_size = 1; // Assuming batch size of 1 for now
+    let kv_capacity = (input_ids.len().max(1) + cfg.max_tokens).min(seq_len);
 
     let log_interval = log_interval_from_env();
     let mut metrics_loggers = MetricsLoggers::from_env(log_interval);
@@ -282,7 +283,7 @@ where
     let model_memory_tree = build_model_memory_tree(qwen);
 
     for layer_idx in 0..n_layers {
-        ctx.alloc_kv_cache(layer_idx, seq_len, batch_size * n_kv_heads, batch_size * n_heads, kv_head_dim)?;
+        ctx.alloc_kv_cache(layer_idx, kv_capacity, batch_size * n_kv_heads, batch_size * n_heads, kv_head_dim)?;
     }
 
     // --- Prompt Processing Pass ---

--- a/src/Metallic/models/qwen25/qwen25_tests.rs
+++ b/src/Metallic/models/qwen25/qwen25_tests.rs
@@ -108,8 +108,9 @@ fn test_kv_cache_correctness() -> Result<(), MetalError> {
     let kv_dim = d_model * n_kv_heads / n_heads;
     let kv_head_dim = kv_dim / n_kv_heads;
     let batch_size = 1;
+    let kv_capacity = prompt_tokens.len().max(1);
     for i in 0..model.config.n_layers {
-        ctx.alloc_kv_cache(i, model.config.seq_len, batch_size * n_kv_heads, batch_size * n_heads, kv_head_dim)?;
+        ctx.alloc_kv_cache(i, kv_capacity, batch_size * n_kv_heads, batch_size * n_heads, kv_head_dim)?;
     }
 
     // --- Multi-step correctness check ---
@@ -290,8 +291,9 @@ fn test_forward_step_records_kv_repeat_phase() -> Result<(), MetalError> {
     let batch_size = 1;
     let canonical_heads = batch_size * model.config.n_kv_heads;
     let repeated_heads = batch_size * model.config.n_heads;
+    let kv_capacity = 1usize;
     for layer_idx in 0..model.config.n_layers {
-        ctx.alloc_kv_cache(layer_idx, model.config.seq_len, canonical_heads, repeated_heads, kv_head_dim)?;
+        ctx.alloc_kv_cache(layer_idx, kv_capacity, canonical_heads, repeated_heads, kv_head_dim)?;
     }
 
     let collector = new_latency_collector(model.config.n_layers);

--- a/src/Metallic/tests/forward_pass_correctness_test.rs
+++ b/src/Metallic/tests/forward_pass_correctness_test.rs
@@ -1418,10 +1418,11 @@ fn test_forward_step_kv_cache_matches_pytorch_logits() -> Result<(), crate::meta
 
     ctx.kv_caches.clear();
     ctx.kv_cache_pool.reset();
+    let kv_capacity = input_ids.len().max(1);
     for layer_idx in 0..n_layers {
         ctx.alloc_kv_cache(
             layer_idx,
-            model.config.seq_len,
+            kv_capacity,
             batch_size * n_kv_heads,
             batch_size * n_heads,
             kv_head_dim,


### PR DESCRIPTION
## Summary
- size KV cache allocations in generation to the active prompt + requested output window
- update unit tests to pass the exercised KV cache capacities and validate repeat stride handling
- refresh instrumentation docs to describe the per-run cache sizing

## Testing
- not run (Metal backend unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d95e3ef98c8326a5778ef44f31ab19