### PR TITLE
Track dtype metadata for pooled Metal KV caches

### DIFF
--- a/src/Metallic/context.rs
+++ b/src/Metallic/context.rs
@@ -418,10 +418,10 @@ impl Context {
         debug_assert_eq!(dtype, repeated_k_allocation.dtype);
         debug_assert_eq!(dtype, repeated_v_allocation.dtype);
 
-        let mut k = k_allocation.into_tensor();
-        let mut v = v_allocation.into_tensor();
-        let mut repeated_k = repeated_k_allocation.into_tensor();
-        let mut repeated_v = repeated_v_allocation.into_tensor();
+        let k = k_allocation.into_tensor();
+        let v = v_allocation.into_tensor();
+        let repeated_k = repeated_k_allocation.into_tensor();
+        let repeated_v = repeated_v_allocation.into_tensor();
 
         // Manually zero the tensors using a blit command
         let k_size = k.size_bytes();
@@ -477,14 +477,14 @@ impl Context {
         let mut k_src = k_step.clone();
         let mut v_src = v_step.clone();
 
-        let dims = k_src.dims();
+        let dims = k_src.dims().to_vec();
         let (bh, seq_in_src, hd) = match dims.len() {
             2 => (dims[0], 1, dims[1]),
             3 => (dims[0], dims[1], dims[2]),
             _ => (0, 0, 0),
         };
 
-        let v_dims = v_src.dims();
+        let v_dims = v_src.dims().to_vec();
         let (v_bh, v_seq_in_src, v_hd) = match v_dims.len() {
             2 => (v_dims[0], 1, v_dims[1]),
             3 => (v_dims[0], v_dims[1], v_dims[2]),

--- a/src/Metallic/context.rs
+++ b/src/Metallic/context.rs
@@ -494,7 +494,7 @@ impl Context {
         if zero_ready {
             self.prepare_tensors_for_active_cmd(&mut [&mut k_src, &mut v_src]);
             self.ensure_active_cmd_buffer()?;
-            let mut encoder = {
+            let encoder = {
                 let cmd_buf = self.active_command_buffer_mut()?;
                 cmd_buf
                     .raw()
@@ -664,7 +664,7 @@ impl Context {
 
         self.ensure_active_cmd_buffer()?;
         {
-            let mut encoder = {
+            let encoder = {
                 let cmd_buf = self.active_command_buffer_mut()?;
                 cmd_buf
                     .raw()
@@ -741,7 +741,7 @@ impl Context {
         let mut k_src = k_step.clone();
         let mut v_src = v_step.clone();
 
-        let k_dims = k_src.dims();
+        let k_dims = k_src.dims().to_vec();
         let (canonical_heads, seq_in_src, head_dim) = match k_dims.len() {
             2 => (k_dims[0], 1, k_dims[1]),
             3 => (k_dims[0], k_dims[1], k_dims[2]),
@@ -753,7 +753,7 @@ impl Context {
             ));
         }
 
-        let v_dims = v_src.dims();
+        let v_dims = v_src.dims().to_vec();
         let (v_heads, v_seq_in_src, v_head_dim) = match v_dims.len() {
             2 => (v_dims[0], 1, v_dims[1]),
             3 => (v_dims[0], v_dims[1], v_dims[2]),
@@ -763,7 +763,7 @@ impl Context {
         if zero_ready {
             self.prepare_tensors_for_active_cmd(&mut [&mut k_src, &mut v_src]);
             self.ensure_active_cmd_buffer()?;
-            let mut encoder = {
+            let encoder = {
                 let cmd_buf = self.active_command_buffer_mut()?;
                 cmd_buf
                     .raw()

--- a/src/Metallic/tensor.rs
+++ b/src/Metallic/tensor.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use super::{Context, MetalError, operation::CommandBuffer};
+use super::{operation::CommandBuffer, Context, MetalError};
 use crate::metallic::encoder::{dispatch_threads, set_buffer, set_bytes, set_compute_pipeline_state};
 use crate::metallic::kernels::elemwise_add::ElemwiseAddOp;
 use crate::metallic::kernels::elemwise_div::ElemwiseDivOp;
@@ -183,7 +183,7 @@ impl Tensor {
     /// Create an uninitialized tensor of given shape using pooled memory.
     #[inline]
     pub fn create_tensor_pooled(dims: Vec<usize>, ctx: &mut Context) -> Result<Tensor, MetalError> {
-        ctx.pool.alloc_tensor(dims)
+        Ok(ctx.pool.alloc_tensor(dims, Dtype::F32)?.into_tensor())
     }
 
     /// Create a tensor view from an existing Metal buffer without copying.


### PR DESCRIPTION
## Summary
- extend the Metal memory pool to return typed `PooledAllocation` records that capture dtype and element size information
- request typed pooled buffers for KV cache setup and persist the metadata together with a zeroing-complete flag
- teach KV cache writers to consume the pooled metadata, using the zeroing flag to skip redundant clones while honouring typed byte widths

## Testing
- `cargo check` *(fails: objc2 only builds on Apple platforms in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d974bacf0c83268e986d37a89e7f59