### PR TITLE
Refine Metal context dispatches to borrow tensors

### DIFF
--- a/IMPROVEMENTS_TODO.md
+++ b/IMPROVEMENTS_TODO.md
@@ -5,9 +5,10 @@ This checklist captures potential optimizations and hardening opportunities disc
 ## ✅ Quick wins
 - [x] Record the dtype and element size in `MemoryPool::alloc_tensor` instead of assuming `f32`; this prevents over-allocation and unlocks pooled storage for `bf16`/`fp16` tensors. (Implemented via `PooledAllocation` metadata on the dedicated KV pool.)
 - [x] Expose pooled tensor allocation for KV cache setup to avoid the extra `clone()` handles that retain buffers longer than necessary. (KV initialization now requests typed pooled buffers directly.)
-- [x] Remove unnecessary `clone()` calls when dispatching operations (e.g., `Context::matmul*`); prefer borrowed tensor handles or lightweight views to cut reference counting churn. (Freshly zeroed KV writes now blit into the canonical cache without cloning cached tensors.)
+- [x] Remove unnecessary `clone()` calls when dispatching operations (e.g., `Context::matmul*`); prefer borrowed tensor handles or lightweight views to cut reference counting churn. (Dispatch helpers now route borrowed tensor arguments through `KernelInvocable::Args`, only cloning when command recording requires ownership, and the kernel tests exercise the borrowed contract.)
 - [ ] Replace repeated manual F16→F32 conversion paths with a single helper and skip debug prints to reduce temporary allocations during GGUF loading. 【F:src/gguf/model_loader.rs†L27-L136】
 - [ ] Audit `ResourceCache::get_or_create_resource`’s dummy-device `transmute` and replace with an explicit optional device handle to avoid UB and simplify lifetime tracking. 【F:src/Metallic/resource_cache.rs†L34-L73】
+- [ ] Add debug assertions (enabled in non-release builds) that ensure borrowed tensor arguments outlive the command buffer submission boundaries now that dispatch helpers avoid cloning. 【F:src/Metallic/context.rs†L60-L161】
 - [x] Plumb explicit synchronization for tensors returned from pooled allocations (e.g., mark when blit zeroing completes) so downstream code can skip redundant `clone()` handles. (KV cache entries track a zeroing-complete flag consumed by fast paths.)
 
 ## ⚙️ Medium-effort improvements

--- a/src/Metallic/kernels/elemwise_add/mod.rs
+++ b/src/Metallic/kernels/elemwise_add/mod.rs
@@ -20,19 +20,19 @@ struct ElemwiseAdd {
 }
 
 impl KernelInvocable for ElemwiseAddOp {
-    type Args = (Tensor, Tensor);
+    type Args<'a> = (Tensor, Tensor);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::ElemwiseAdd)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut a, mut b) = args;
+        let (a, b) = args;
         if a.dims() != b.dims() {
             return Err(MetalError::InvalidShape(format!(
                 "ElemwiseAdd: input shapes must match, got a={:?}, b={:?}",
@@ -40,7 +40,7 @@ impl KernelInvocable for ElemwiseAddOp {
                 b.dims(),
             )));
         }
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut a, &mut b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
         let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
         let op = ElemwiseAdd {
             a,

--- a/src/Metallic/kernels/elemwise_div/mod.rs
+++ b/src/Metallic/kernels/elemwise_div/mod.rs
@@ -12,19 +12,19 @@ struct ElemwiseDiv {
 }
 
 impl KernelInvocable for ElemwiseDivOp {
-    type Args = (Tensor, Tensor);
+    type Args<'a> = (Tensor, Tensor);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::ElemwiseDiv)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut a, mut b) = args;
+        let (a, b) = args;
         if a.dims() != b.dims() {
             return Err(MetalError::InvalidShape(format!(
                 "ElemwiseDiv: input shapes must match, got a={:?}, b={:?}",
@@ -33,7 +33,7 @@ impl KernelInvocable for ElemwiseDivOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut a, &mut b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
         let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
 

--- a/src/Metallic/kernels/elemwise_mul/mod.rs
+++ b/src/Metallic/kernels/elemwise_mul/mod.rs
@@ -12,19 +12,19 @@ struct ElemwiseMul {
 }
 
 impl KernelInvocable for ElemwiseMulOp {
-    type Args = (Tensor, Tensor);
+    type Args<'a> = (Tensor, Tensor);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::ElemwiseMul)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut a, mut b) = args;
+        let (a, b) = args;
         if a.dims() != b.dims() {
             return Err(MetalError::InvalidShape(format!(
                 "ElemwiseMul: input shapes must match, got a={:?}, b={:?}",
@@ -33,7 +33,7 @@ impl KernelInvocable for ElemwiseMulOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut a, &mut b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
         let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
 

--- a/src/Metallic/kernels/elemwise_sub/mod.rs
+++ b/src/Metallic/kernels/elemwise_sub/mod.rs
@@ -12,19 +12,19 @@ struct ElemwiseSub {
 }
 
 impl KernelInvocable for ElemwiseSubOp {
-    type Args = (Tensor, Tensor);
+    type Args<'a> = (Tensor, Tensor);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::ElemwiseSub)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut a, mut b) = args;
+        let (a, b) = args;
         if a.dims() != b.dims() {
             return Err(MetalError::InvalidShape(format!(
                 "ElemwiseSub: input shapes must match, got a={:?}, b={:?}",
@@ -33,7 +33,7 @@ impl KernelInvocable for ElemwiseSubOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut a, &mut b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
         let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
 

--- a/src/Metallic/kernels/gelu/mod.rs
+++ b/src/Metallic/kernels/gelu/mod.rs
@@ -9,20 +9,20 @@ struct Gelu {
 }
 
 impl KernelInvocable for GeluOp {
-    type Args = Tensor;
+    type Args<'a> = Tensor;
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::Gelu)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        input: Self::Args,
+        input: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let mut input = input;
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut input]);
+        let input = input;
+        ctx.prepare_tensors_for_active_cmd(&[&input]);
 
         let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
 

--- a/src/Metallic/kernels/kernel_manager.rs
+++ b/src/Metallic/kernels/kernel_manager.rs
@@ -2,14 +2,14 @@ use super::*;
 
 /// A trait for kernel operations that can be invoked via `Context::call`.
 pub trait KernelInvocable {
-    type Args;
+    type Args<'a>;
 
     fn function_id() -> Option<KernelFunction>;
 
     #[allow(clippy::new_ret_no_self)]
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError>;

--- a/src/Metallic/kernels/matmul/matmul_test.rs
+++ b/src/Metallic/kernels/matmul/matmul_test.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use crate::metallic::kernels::matmul::{MatMulAlphaBetaOp, MatMulOp, mps_matrix_from_buffer};
+use crate::metallic::kernels::matmul::{mps_matrix_from_buffer, MatMulAlphaBetaOp, MatMulOp};
 use crate::metallic::{Context, MetalError, Tensor};
 
 // Helpers
@@ -156,7 +156,7 @@ fn test_matmul_correctness_small_int() -> Result<(), MetalError> {
     let cpu_output = cpu_matmul(&a_data, 2, 3, &b_data, 3, 2, false, false);
 
     // Use the new kernel system
-    let result_tensor = context.call::<MatMulOp>((a_tensor, b_tensor, false, false))?;
+    let result_tensor = context.call::<MatMulOp>((&a_tensor, &b_tensor, false, false))?;
     context.synchronize();
 
     let metal_output = result_tensor.as_slice();
@@ -182,7 +182,7 @@ fn test_matmul_correctness_asymmetric_float() -> Result<(), MetalError> {
     let cpu_output = cpu_matmul(&a_data, 5, 4, &b_data, 4, 7, false, false);
 
     // Use the new kernel system
-    let result_tensor = context.call::<MatMulOp>((a_tensor, b_tensor, false, false))?;
+    let result_tensor = context.call::<MatMulOp>((&a_tensor, &b_tensor, false, false))?;
     context.synchronize();
 
     let metal_output = result_tensor.as_slice();
@@ -225,7 +225,7 @@ fn test_matmul_transpose_right() -> Result<(), MetalError> {
     let cpu_output = cpu_matmul(&a_data, 2, 3, &b_data, 2, 3, false, true);
 
     // Use the new kernel system
-    let result_tensor = context.call::<MatMulOp>((a_tensor, b_tensor, false, true))?; // transpose right only
+    let result_tensor = context.call::<MatMulOp>((&a_tensor, &b_tensor, false, true))?; // transpose right only
     context.synchronize();
 
     let metal_output = result_tensor.as_slice();
@@ -268,7 +268,7 @@ fn test_matmul_transpose_left() -> Result<(), MetalError> {
     let cpu_output = cpu_matmul(&a_data, 2, 3, &b_data, 2, 3, true, false);
 
     // Use the new kernel system
-    let result_tensor = context.call::<MatMulOp>((a_tensor, b_tensor, true, false))?; // transpose left only
+    let result_tensor = context.call::<MatMulOp>((&a_tensor, &b_tensor, true, false))?; // transpose left only
     context.synchronize();
 
     let metal_output = result_tensor.as_slice();
@@ -321,7 +321,7 @@ fn test_matmul_alpha_beta_accumulation() -> Result<(), MetalError> {
     let expected_result = [15.625, 9.875, 43.125, 28.375];
 
     // Use the new kernel system with alpha/beta scaling
-    let result_tensor = context.call::<MatMulAlphaBetaOp>((a_tensor, b_tensor, c_tensor, false, false, alpha, beta))?;
+    let result_tensor = context.call::<MatMulAlphaBetaOp>((&a_tensor, &b_tensor, &c_tensor, false, false, alpha, beta))?;
     context.synchronize();
 
     let metal_output = result_tensor.as_slice();

--- a/src/Metallic/kernels/permute/mod.rs
+++ b/src/Metallic/kernels/permute/mod.rs
@@ -11,19 +11,19 @@ struct Permute {
 }
 
 impl KernelInvocable for PermuteOp {
-    type Args = (Tensor, Vec<u32>);
+    type Args<'a> = (Tensor, Vec<u32>);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::Permute)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut src, permute) = args;
+        let (src, permute) = args;
 
         // Validate permutation
         if permute.len() != src.dims().len() {
@@ -47,7 +47,7 @@ impl KernelInvocable for PermuteOp {
             out_dims[i] = src.dims()[p_idx as usize];
         }
 
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut src]);
+        ctx.prepare_tensors_for_active_cmd(&[&src]);
 
         // Create the output tensor
         let dst = Tensor::create_tensor_pooled(out_dims, ctx)?;

--- a/src/Metallic/kernels/repeat_kv_heads/mod.rs
+++ b/src/Metallic/kernels/repeat_kv_heads/mod.rs
@@ -17,19 +17,19 @@ struct RepeatKvHeads {
 }
 
 impl KernelInvocable for RepeatKvHeadsOp {
-    type Args = (Tensor, u32, u32, u32, u32, u32, u32, u32);
+    type Args<'a> = (Tensor, u32, u32, u32, u32, u32, u32, u32);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::RepeatKvHeads)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut input, group_size, batch, n_kv_heads, n_heads, seq, head_dim, cache_stride) = args;
+        let (input, group_size, batch, n_kv_heads, n_heads, seq, head_dim, cache_stride) = args;
 
         if group_size == 0 {
             return Err(MetalError::InvalidShape(
@@ -94,7 +94,7 @@ impl KernelInvocable for RepeatKvHeadsOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut input]);
+        ctx.prepare_tensors_for_active_cmd(&[&input]);
 
         let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];
         let output = Tensor::create_tensor_pooled(output_dims, ctx)?;

--- a/src/Metallic/kernels/rmsnorm/mod.rs
+++ b/src/Metallic/kernels/rmsnorm/mod.rs
@@ -11,19 +11,19 @@ struct RMSNorm {
 }
 
 impl KernelInvocable for RMSNormOp {
-    type Args = (Tensor, Tensor, u32); // (input, gamma, feature_dim)
+    type Args<'a> = (Tensor, Tensor, u32); // (input, gamma, feature_dim)
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::RMSNorm)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let (mut input, mut gamma, feature_dim) = args;
+        let (input, gamma, feature_dim) = args;
 
         // Validate dimensions
         if input.dims().last() != Some(&(feature_dim as usize)) {
@@ -41,7 +41,7 @@ impl KernelInvocable for RMSNormOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut input, &mut gamma]);
+        ctx.prepare_tensors_for_active_cmd(&[&input, &gamma]);
 
         let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
 

--- a/src/Metallic/kernels/silu/mod.rs
+++ b/src/Metallic/kernels/silu/mod.rs
@@ -11,20 +11,20 @@ struct Silu {
 }
 
 impl KernelInvocable for SiluOp {
-    type Args = Tensor;
+    type Args<'a> = Tensor;
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::Silu)
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        input: Self::Args,
+        input: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
-        let mut input = input;
-        ctx.prepare_tensors_for_active_cmd(&mut [&mut input]);
+        let input = input;
+        ctx.prepare_tensors_for_active_cmd(&[&input]);
 
         let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
 

--- a/src/Metallic/kernels/softmax/softmax_test.rs
+++ b/src/Metallic/kernels/softmax/softmax_test.rs
@@ -46,7 +46,7 @@ fn test_softmax_golden_non_causal() -> Result<(), MetalError> {
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
     // Apply softmax using the new kernel system (in-place operation)
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -96,7 +96,7 @@ fn test_softmax_golden_causal() -> Result<(), MetalError> {
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true);
 
     // Apply softmax using the new kernel system (in-place operation) with causal masking
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -167,7 +167,7 @@ fn test_softmax_extremes_large_positive_values() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -234,7 +234,7 @@ fn test_softmax_extremes_large_negative_values() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -301,7 +301,7 @@ fn test_softmax_extremes_identical_values() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -383,7 +383,7 @@ fn test_softmax_extremes_single_large_outlier() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -467,7 +467,7 @@ fn test_softmax_extremes_causal_with_extremes() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -598,7 +598,7 @@ fn test_softmax_extremes_underflow_scenarios() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -674,7 +674,7 @@ fn test_softmax_extremes_infinity_scenarios() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -761,7 +761,7 @@ fn test_softmax_extremes_nan_scenarios() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -811,7 +811,7 @@ fn test_softmax_extremes_large_sequences() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -880,7 +880,7 @@ fn test_softmax_extremes_very_large_positive_and_negative_mixed() -> Result<(), 
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -947,7 +947,7 @@ fn test_softmax_irregular_sizes_1() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -997,7 +997,7 @@ fn test_softmax_irregular_sizes_2() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -1047,7 +1047,7 @@ fn test_softmax_causal_irregular_sizes() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true);
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -1112,7 +1112,7 @@ fn test_softmax_causal_large_irregular() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true); // Using causal=true
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -1191,7 +1191,7 @@ fn test_softmax_threadgroup_execution_width() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1226,7 +1226,7 @@ fn test_softmax_threadgroup_large_seq_k() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1261,7 +1261,7 @@ fn test_softmax_threadgroup_very_large_seq_k() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1296,7 +1296,7 @@ fn test_softmax_threadgroup_multiple_rows() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1327,7 +1327,7 @@ fn test_softmax_logic() -> Result<(), MetalError> {
     let input_data = vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0]; // Two rows to softmax independently
     let attn = Tensor::create_tensor_from_slice(&input_data, vec![2, 3], &ctx)?;
     // Apply softmax with no causal masking (causal=0)
-    let result = ctx.call::<SoftmaxOp>((attn, 2, 3, 0, 0))?;
+    let result = ctx.call::<SoftmaxOp>((&attn, 2, 3, 0, 0))?;
     // Check that each row sums to approximately 1 (property of softmax)
     let result_slice = result.as_slice();
     let row1_sum: f32 = result_slice[0..3].iter().sum();

--- a/src/Metallic/kernels/swiglu/mod.rs
+++ b/src/Metallic/kernels/swiglu/mod.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-use crate::metallic::Context;
-use crate::metallic::MetalError;
-use crate::metallic::Tensor;
 use crate::metallic::kernels::elemwise_add::BroadcastElemwiseAddOp;
 use crate::metallic::kernels::elemwise_mul::ElemwiseMulOp;
 use crate::metallic::kernels::silu::SiluOp;
+use crate::metallic::Context;
+use crate::metallic::MetalError;
+use crate::metallic::Tensor;
 
 /// SwiGLU operation that computes: down_proj( SiLU(gate_proj(x)) * up_proj(x) )
 pub struct SwiGLUOp;
@@ -14,16 +14,16 @@ pub struct SwiGLUOp;
 pub struct SwiGLU;
 
 impl KernelInvocable for SwiGLUOp {
-    type Args = (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor);
+    type Args<'a> = (&'a Tensor, &'a Tensor, &'a Tensor, &'a Tensor, &'a Tensor, &'a Tensor, &'a Tensor);
 
     fn function_id() -> Option<KernelFunction> {
         // This is a composite operation using existing kernels, so we don't need a specific kernel function
         None
     }
 
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         _pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
@@ -51,32 +51,16 @@ impl KernelInvocable for SwiGLUOp {
 #[allow(clippy::too_many_arguments)]
 fn execute_swiglu_logic(
     ctx: &mut Context,
-    x_normed_flat: Tensor,
-    ffn_gate: Tensor,
-    ffn_gate_bias: Tensor,
-    ffn_up: Tensor,
-    ffn_up_bias: Tensor,
-    ffn_down: Tensor,
-    ffn_down_bias: Tensor,
+    x_normed_flat: &Tensor,
+    ffn_gate: &Tensor,
+    ffn_gate_bias: &Tensor,
+    ffn_up: &Tensor,
+    ffn_up_bias: &Tensor,
+    ffn_down: &Tensor,
+    ffn_down_bias: &Tensor,
     mut cache: Option<&mut ResourceCache>,
 ) -> Result<Tensor, MetalError> {
-    let mut x_normed_flat = x_normed_flat;
-    let mut ffn_gate = ffn_gate;
-    let mut ffn_gate_bias = ffn_gate_bias;
-    let mut ffn_up = ffn_up;
-    let mut ffn_up_bias = ffn_up_bias;
-    let mut ffn_down = ffn_down;
-    let mut ffn_down_bias = ffn_down_bias;
-
-    ctx.prepare_tensors_for_active_cmd(&mut [
-        &mut x_normed_flat,
-        &mut ffn_gate,
-        &mut ffn_gate_bias,
-        &mut ffn_up,
-        &mut ffn_up_bias,
-        &mut ffn_down,
-        &mut ffn_down_bias,
-    ]);
+    ctx.prepare_tensors_for_active_cmd(&[x_normed_flat, ffn_gate, ffn_gate_bias, ffn_up, ffn_up_bias, ffn_down, ffn_down_bias]);
     let d_model = x_normed_flat.dims()[1];
 
     // gate_proj: [m, d_model] @ weight -> [m, ff_dim]
@@ -92,14 +76,14 @@ fn execute_swiglu_logic(
         });
     };
     let gate_temp = match cache.as_mut() {
-        Some(cache) => ctx.matmul_with_cache(&x_normed_flat, &ffn_gate, false, gate_transpose_b, cache)?,
-        None => ctx.matmul(&x_normed_flat, &ffn_gate, false, gate_transpose_b)?,
+        Some(cache) => ctx.matmul_with_cache(x_normed_flat, ffn_gate, false, gate_transpose_b, cache)?,
+        None => ctx.matmul(x_normed_flat, ffn_gate, false, gate_transpose_b)?,
     };
 
     // Add gate bias (broadcast over last dim)
     let gate_out = match cache.as_mut() {
-        Some(cache) => ctx.call_with_cache::<BroadcastElemwiseAddOp>((gate_temp, ffn_gate_bias), cache)?,
-        None => ctx.call::<BroadcastElemwiseAddOp>((gate_temp, ffn_gate_bias))?,
+        Some(cache) => ctx.call_with_cache::<BroadcastElemwiseAddOp>((gate_temp, ffn_gate_bias.clone()), cache)?,
+        None => ctx.call::<BroadcastElemwiseAddOp>((gate_temp, ffn_gate_bias.clone()))?,
     };
 
     // up_proj: [m, d_model] @ weight -> [m, ff_dim]
@@ -115,14 +99,14 @@ fn execute_swiglu_logic(
         });
     };
     let up_temp = match cache.as_mut() {
-        Some(cache) => ctx.matmul_with_cache(&x_normed_flat, &ffn_up, false, up_transpose_b, cache)?,
-        None => ctx.matmul(&x_normed_flat, &ffn_up, false, up_transpose_b)?,
+        Some(cache) => ctx.matmul_with_cache(x_normed_flat, ffn_up, false, up_transpose_b, cache)?,
+        None => ctx.matmul(x_normed_flat, ffn_up, false, up_transpose_b)?,
     };
 
     // Add up bias
     let up_out = match cache.as_mut() {
-        Some(cache) => ctx.call_with_cache::<BroadcastElemwiseAddOp>((up_temp, ffn_up_bias), cache)?,
-        None => ctx.call::<BroadcastElemwiseAddOp>((up_temp, ffn_up_bias))?,
+        Some(cache) => ctx.call_with_cache::<BroadcastElemwiseAddOp>((up_temp, ffn_up_bias.clone()), cache)?,
+        None => ctx.call::<BroadcastElemwiseAddOp>((up_temp, ffn_up_bias.clone()))?,
     };
 
     // SiLU activation on gate_proj
@@ -144,14 +128,14 @@ fn execute_swiglu_logic(
     let ffn_temp = if hidden_cols == ffn_down_rows {
         // Hidden [m, ff_dim] @ ffn_down [ff_dim, d_model] -> [m, d_model]
         match cache.as_mut() {
-            Some(cache) => ctx.matmul_with_cache(&hidden, &ffn_down, false, false, cache)?,
-            None => ctx.matmul(&hidden, &ffn_down, false, false)?,
+            Some(cache) => ctx.matmul_with_cache(&hidden, ffn_down, false, false, cache)?,
+            None => ctx.matmul(&hidden, ffn_down, false, false)?,
         }
     } else if hidden_cols == ffn_down_cols {
         // Hidden [m, ff_dim] @ ffn_down^T [ff_dim, d_model] where stored as [d_model, ff_dim]
         match cache.as_mut() {
-            Some(cache) => ctx.matmul_with_cache(&hidden, &ffn_down, false, true, cache)?,
-            None => ctx.matmul(&hidden, &ffn_down, false, true)?,
+            Some(cache) => ctx.matmul_with_cache(&hidden, ffn_down, false, true, cache)?,
+            None => ctx.matmul(&hidden, ffn_down, false, true)?,
         }
     } else {
         return Err(MetalError::DimensionMismatch {
@@ -162,8 +146,8 @@ fn execute_swiglu_logic(
 
     // Add down bias to final projection output
     let ffn_out = match cache.as_mut() {
-        Some(cache) => ctx.call_with_cache::<BroadcastElemwiseAddOp>((ffn_temp, ffn_down_bias), cache)?,
-        None => ctx.call::<BroadcastElemwiseAddOp>((ffn_temp, ffn_down_bias))?,
+        Some(cache) => ctx.call_with_cache::<BroadcastElemwiseAddOp>((ffn_temp, ffn_down_bias.clone()), cache)?,
+        None => ctx.call::<BroadcastElemwiseAddOp>((ffn_temp, ffn_down_bias.clone()))?,
     };
 
     Ok(ffn_out)
@@ -188,13 +172,13 @@ pub fn swiglu_with_optional_cache(
 ) -> Result<Tensor, MetalError> {
     execute_swiglu_logic(
         ctx,
-        x_normed_flat.clone(),
-        ffn_gate.clone(),
-        ffn_gate_bias.clone(),
-        ffn_up.clone(),
-        ffn_up_bias.clone(),
-        ffn_down.clone(),
-        ffn_down_bias.clone(),
+        x_normed_flat,
+        ffn_gate,
+        ffn_gate_bias,
+        ffn_up,
+        ffn_up_bias,
+        ffn_down,
+        ffn_down_bias,
         cache,
     )
 }

--- a/src/Metallic/kernels/tensors/arange.rs
+++ b/src/Metallic/kernels/tensors/arange.rs
@@ -14,7 +14,7 @@ struct Arange {
 // 3. Implement `KernelInvocable` for the public struct.
 impl KernelInvocable for ArangeOp {
     // Input arguments for the call.
-    type Args = usize;
+    type Args<'a> = usize;
     // The output type.
 
     // Link to the enum variant in `KernelFunction`.
@@ -24,9 +24,9 @@ impl KernelInvocable for ArangeOp {
 
     // This `new` method is called by `ctx.call()`.
     // It creates the output tensor and the internal `Operation` struct.
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        length: Self::Args,
+        length: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {

--- a/src/Metallic/kernels/tensors/ones.rs
+++ b/src/Metallic/kernels/tensors/ones.rs
@@ -14,7 +14,7 @@ struct Ones {
 // 3. Implement `KernelInvocable` for the public struct.
 impl KernelInvocable for OnesOp {
     // Input arguments for the call.
-    type Args = Vec<usize>;
+    type Args<'a> = Vec<usize>;
     // The output type.
 
     // Link to the enum variant in `KernelFunction`.
@@ -24,9 +24,9 @@ impl KernelInvocable for OnesOp {
 
     // This `new` method is called by `ctx.call()`.
     // It creates the output tensor and the internal `Operation` struct.
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        dims: Self::Args,
+        dims: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {

--- a/src/Metallic/kernels/tensors/random_uniform.rs
+++ b/src/Metallic/kernels/tensors/random_uniform.rs
@@ -17,7 +17,7 @@ struct RandomUniform {
 // 3. Implement `KernelInvocable` for the public struct.
 impl KernelInvocable for RandomUniformOp {
     // Input arguments for the call.
-    type Args = (Vec<usize>, f32, f32, Option<u32>);
+    type Args<'a> = (Vec<usize>, f32, f32, Option<u32>);
     // The output type.
 
     // Link to the enum variant in `KernelFunction`.
@@ -27,9 +27,9 @@ impl KernelInvocable for RandomUniformOp {
 
     // This `new` method is called by `ctx.call()`.
     // It creates the output tensor and the internal `Operation` struct.
-    fn new(
+    fn new<'a>(
         ctx: &mut Context,
-        args: Self::Args,
+        args: Self::Args<'a>,
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {

--- a/src/Metallic/tests/determinism_test.rs
+++ b/src/Metallic/tests/determinism_test.rs
@@ -188,7 +188,7 @@ fn test_softmax_determinism() -> Result<(), MetalError> {
         let attn_tensor = input_tensor.clone();
 
         // Apply softmax using the new kernel system (in-place operation)
-        let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+        let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
         context.synchronize();
 
         results.push(result.as_slice().to_vec());

--- a/src/Metallic/tests/error_path_test.rs
+++ b/src/Metallic/tests/error_path_test.rs
@@ -227,7 +227,7 @@ fn test_softmax_invalid_dimensions() {
     let result = Tensor::create_tensor_from_slice(&input_data, dims, &context);
     // This might fail at tensor creation time
     if let Ok(attn_tensor) = result {
-        let result = context.call::<SoftmaxOp>((attn_tensor, seq_q as u32, seq_k as u32, 0, 0));
+        let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0));
         // Should not panic, but might return an error
         assert!(result.is_ok() || result.is_err());
     }


### PR DESCRIPTION
## Summary
- replace tensor cloning in Metal context dispatch helpers with borrowed handles
- update KernelInvocable trait and kernel implementations to accept borrowed tensor arguments and refreshed preparation API
- adjust softmax, matmul, SDPA, and SwiGLU paths plus tests to leverage the new borrowing model

## Testing
- not run (Metal execution unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d97d47a9b08326842874245a6abb83