### PR TITLE
Refactor F16 conversion in GGUF model loader

### DIFF
--- a/src/gguf/model_loader.rs
+++ b/src/gguf/model_loader.rs
@@ -1,9 +1,26 @@
 use super::{GGUFDataType, GGUFError, GGUFFile};
 use crate::{
     gguf::GGUFValue,
-    metallic::{Context, Tensor, resource_cache::ResourceCache},
+    metallic::{resource_cache::ResourceCache, Context, Tensor},
 };
+use half::f16;
 use std::collections::HashMap;
+
+fn convert_f16_bytes(raw: &[u8]) -> Result<Vec<f32>, GGUFError> {
+    if raw.len() % 2 != 0 {
+        return Err(GGUFError::InvalidTensorData("F16 tensor byte length must be even".to_string()));
+    }
+
+    let elem_count = raw.len() / 2;
+    let mut f32_data = Vec::with_capacity(elem_count);
+
+    for chunk in raw.chunks_exact(2) {
+        let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+        f32_data.push(f16::from_bits(bits).to_f32());
+    }
+
+    Ok(f32_data)
+}
 
 /// A model loader that can construct a Metallic model from GGUF tensors
 pub struct GGUFModelLoader {
@@ -38,15 +55,13 @@ impl GGUFModelLoader {
                         //if tensor_info.name == "token_embd.weight" {
                         //    println!("First F16 bytes: {:02x?} {:02x?}", raw[0], raw[1]);
                         //}
-                        let elem_count = raw.len() / 2;
-                        let mut f32_data = Vec::with_capacity(elem_count);
-                        for i in 0..elem_count {
-                            let lo = raw[2 * i] as u16;
-                            let hi = raw[2 * i + 1] as u16;
-                            let bits = lo | (hi << 8); // Little-endian: low byte first
-                            let h = half::f16::from_bits(bits);
-                            f32_data.push(h.to_f32());
-                        }
+                        let f32_data = match convert_f16_bytes(raw) {
+                            Ok(data) => data,
+                            Err(e) => {
+                                println!("Warning: failed to convert F16 tensor bytes '{}': {:?}", tensor_info.name, e);
+                                continue;
+                            }
+                        };
                         let mut dims: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
                         // Special case for embedding: swap dims if it's [d_model, vocab] but data laid out as [vocab, d_model]
                         if tensor_info.name == "token_embd.weight" && dims.len() == 2 && dims[0] == 896 && dims[1] == 151936 {
@@ -122,27 +137,13 @@ impl GGUFModelLoader {
                             // Try to get raw bytes and convert F16 to F32
                             match self.gguf_file.get_tensor_data(tensor_info) {
                                 Ok(raw) => {
-                                    println!("Converting F16 tensor '{}' with {} bytes", tensor_info.name, raw.len());
-                                    // Manual F16 conversion
-                                    let elem_count = raw.len() / 2;
-                                    let mut f32_data = Vec::with_capacity(elem_count);
-                                    for i in 0..std::cmp::min(10, elem_count) {
-                                        let lo = raw[2 * i] as u16;
-                                        let hi = raw[2 * i + 1] as u16;
-                                        let bits = lo | (hi << 8);
-                                        let h = half::f16::from_bits(bits);
-                                        let f32_val = h.to_f32();
-                                        println!("  F16[{}] bits=0x{:04x} -> f32={}", i, bits, f32_val);
-                                        f32_data.push(f32_val);
-                                    }
-                                    // Add the rest of the data
-                                    for i in 10..elem_count {
-                                        let lo = raw[2 * i] as u16;
-                                        let hi = raw[2 * i + 1] as u16;
-                                        let bits = lo | (hi << 8);
-                                        let h = half::f16::from_bits(bits);
-                                        f32_data.push(h.to_f32());
-                                    }
+                                    let f32_data = match convert_f16_bytes(raw) {
+                                        Ok(data) => data,
+                                        Err(e) => {
+                                            println!("Warning: failed to convert F16 tensor bytes '{}': {:?}", tensor_info.name, e);
+                                            continue;
+                                        }
+                                    };
                                     let mut dims: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
                                     // Special case for embedding: swap dims if it's [d_model, vocab] but data laid out as [vocab, d_model]
                                     if tensor_info.name == "token_embd.weight" && dims.len() == 2 && dims[0] == 896 && dims[1] == 151936 {
@@ -151,20 +152,6 @@ impl GGUFModelLoader {
                                     }
                                     match crate::metallic::Tensor::create_tensor_from_slice(&f32_data, dims, _context) {
                                         Ok(t) => {
-                                            println!("Successfully converted F16 tensor '{}'", tensor_info.name);
-                                            // Check some values
-                                            let slice = t.as_slice();
-                                            println!(
-                                                "First 10 values of '{}': {:?}",
-                                                tensor_info.name,
-                                                &slice[..std::cmp::min(10, slice.len())]
-                                            );
-                                            if tensor_info.name == "output.weight" {
-                                                println!(
-                                                    "First 10 values of output.weight: {:?}",
-                                                    &slice[0..std::cmp::min(10, slice.len())]
-                                                );
-                                            }
                                             tensors.insert(tensor_info.name.clone(), t);
                                         }
                                         Err(e) => {


### PR DESCRIPTION
## Summary
- add a reusable helper to convert F16 tensor bytes to f32 values
- replace duplicated conversion logic in the GGUF model loader and drop debug prints

## Testing
- rustfmt --edition 2021 src/gguf/model_loader.rs

------
https://chatgpt.com/codex/tasks/task_e_68d983640bf48326b6e706db57c1b440