### PR TITLE
Enable batched MPS matmul in SDPA

### DIFF
--- a/benches/sdpa_variant_benchmark.rs
+++ b/benches/sdpa_variant_benchmark.rs
@@ -1,9 +1,9 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
+use test_burn::metallic::kernels::KernelInvocable;
 use test_burn::metallic::kernels::scaled_dot_product_attention::{
     ScaledDotProductAttentionMpsSoftmaxOp, ScaledDotProductAttentionNoPermuteOp, ScaledDotProductAttentionOp,
     ScaledDotProductAttentionOptimizedOp, ScaledDotProductAttentionWorkspaceOp,
 };
-use test_burn::metallic::kernels::KernelInvocable;
 use test_burn::metallic::{Context, Tensor};
 
 const ITERATIONS: usize = 1;

--- a/benches/sdpa_variant_benchmark.rs
+++ b/benches/sdpa_variant_benchmark.rs
@@ -1,21 +1,15 @@
-use criterion::{Criterion, criterion_group, criterion_main};
-use test_burn::metallic::kernels::KernelInvocable;
+use criterion::{criterion_group, criterion_main, Criterion};
 use test_burn::metallic::kernels::scaled_dot_product_attention::{
     ScaledDotProductAttentionMpsSoftmaxOp, ScaledDotProductAttentionNoPermuteOp, ScaledDotProductAttentionOp,
     ScaledDotProductAttentionOptimizedOp, ScaledDotProductAttentionWorkspaceOp,
 };
+use test_burn::metallic::kernels::KernelInvocable;
 use test_burn::metallic::{Context, Tensor};
 
 const ITERATIONS: usize = 1;
 
-fn run_variant<O>(
-    ctx: &mut Context,
-    batch: usize,
-    seq_q: usize,
-    seq_k: usize,
-    dim: usize,
-    causal: bool,
-) where
+fn run_variant_batched<O>(ctx: &mut Context, batch: usize, seq_q: usize, seq_k: usize, dim: usize, causal: bool)
+where
     O: for<'a> KernelInvocable<Args<'a> = (&'a Tensor, &'a Tensor, &'a Tensor, bool, u32)>,
 {
     let q_tensor = Tensor::random_uniform(vec![batch, seq_q, dim], ctx).unwrap();
@@ -25,10 +19,40 @@ fn run_variant<O>(
     let mut last_output = None;
 
     for _ in 0..ITERATIONS {
-        let out = ctx
-            .call::<O>((&q_tensor, &k_tensor, &v_tensor, causal, 0u32))
-            .unwrap();
+        let out = ctx.call::<O>((&q_tensor, &k_tensor, &v_tensor, causal, 0u32)).unwrap();
         last_output = Some(out);
+    }
+
+    if let Some(tensor) = last_output {
+        let _ = tensor.to_vec();
+    }
+}
+
+fn run_variant_per_batch<O>(ctx: &mut Context, batch: usize, seq_q: usize, seq_k: usize, dim: usize, causal: bool)
+where
+    O: for<'a> KernelInvocable<Args<'a> = (&'a Tensor, &'a Tensor, &'a Tensor, bool, u32)>,
+{
+    let q_tensor = Tensor::random_uniform(vec![batch, seq_q, dim], ctx).unwrap();
+    let k_tensor = Tensor::random_uniform(vec![batch, seq_k, dim], ctx).unwrap();
+    let v_tensor = Tensor::random_uniform(vec![batch, seq_k, dim], ctx).unwrap();
+
+    let q_batches: Vec<Tensor> = (0..batch)
+        .map(|i| q_tensor.get_batch(i).unwrap().reshape(vec![1, seq_q, dim]).unwrap())
+        .collect();
+    let k_batches: Vec<Tensor> = (0..batch)
+        .map(|i| k_tensor.get_batch(i).unwrap().reshape(vec![1, seq_k, dim]).unwrap())
+        .collect();
+    let v_batches: Vec<Tensor> = (0..batch)
+        .map(|i| v_tensor.get_batch(i).unwrap().reshape(vec![1, seq_k, dim]).unwrap())
+        .collect();
+
+    let mut last_output = None;
+
+    for _ in 0..ITERATIONS {
+        for i in 0..batch {
+            let out = ctx.call::<O>((&q_batches[i], &k_batches[i], &v_batches[i], causal, 0u32)).unwrap();
+            last_output = Some(out);
+        }
     }
 
     if let Some(tensor) = last_output {
@@ -46,47 +70,92 @@ fn benchmark_sdpa_variants(c: &mut Criterion) {
     let dim = 64;
     let causal = false;
 
-    group.bench_function("baseline", |b| {
+    group.bench_function("baseline_batched", |b| {
         b.iter(|| {
             context.synchronize();
             context.pool.reset();
-            run_variant::<ScaledDotProductAttentionOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            run_variant_batched::<ScaledDotProductAttentionOp>(&mut context, batch, seq_q, seq_k, dim, causal);
             context.synchronize();
         })
     });
 
-    group.bench_function("no_permute", |b| {
+    group.bench_function("baseline_per_batch", |b| {
         b.iter(|| {
             context.synchronize();
             context.pool.reset();
-            run_variant::<ScaledDotProductAttentionNoPermuteOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            run_variant_per_batch::<ScaledDotProductAttentionOp>(&mut context, batch, seq_q, seq_k, dim, causal);
             context.synchronize();
         })
     });
 
-    group.bench_function("workspace_reuse", |b| {
+    group.bench_function("no_permute_batched", |b| {
         b.iter(|| {
             context.synchronize();
             context.pool.reset();
-            run_variant::<ScaledDotProductAttentionWorkspaceOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            run_variant_batched::<ScaledDotProductAttentionNoPermuteOp>(&mut context, batch, seq_q, seq_k, dim, causal);
             context.synchronize();
         })
     });
 
-    group.bench_function("mps_softmax", |b| {
+    group.bench_function("no_permute_per_batch", |b| {
         b.iter(|| {
             context.synchronize();
             context.pool.reset();
-            run_variant::<ScaledDotProductAttentionMpsSoftmaxOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            run_variant_per_batch::<ScaledDotProductAttentionNoPermuteOp>(&mut context, batch, seq_q, seq_k, dim, causal);
             context.synchronize();
         })
     });
 
-    group.bench_function("all_optimizations", |b| {
+    group.bench_function("workspace_reuse_batched", |b| {
         b.iter(|| {
             context.synchronize();
             context.pool.reset();
-            run_variant::<ScaledDotProductAttentionOptimizedOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            run_variant_batched::<ScaledDotProductAttentionWorkspaceOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            context.synchronize();
+        })
+    });
+
+    group.bench_function("workspace_reuse_per_batch", |b| {
+        b.iter(|| {
+            context.synchronize();
+            context.pool.reset();
+            run_variant_per_batch::<ScaledDotProductAttentionWorkspaceOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            context.synchronize();
+        })
+    });
+
+    group.bench_function("mps_softmax_batched", |b| {
+        b.iter(|| {
+            context.synchronize();
+            context.pool.reset();
+            run_variant_batched::<ScaledDotProductAttentionMpsSoftmaxOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            context.synchronize();
+        })
+    });
+
+    group.bench_function("mps_softmax_per_batch", |b| {
+        b.iter(|| {
+            context.synchronize();
+            context.pool.reset();
+            run_variant_per_batch::<ScaledDotProductAttentionMpsSoftmaxOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            context.synchronize();
+        })
+    });
+
+    group.bench_function("all_optimizations_batched", |b| {
+        b.iter(|| {
+            context.synchronize();
+            context.pool.reset();
+            run_variant_batched::<ScaledDotProductAttentionOptimizedOp>(&mut context, batch, seq_q, seq_k, dim, causal);
+            context.synchronize();
+        })
+    });
+
+    group.bench_function("all_optimizations_per_batch", |b| {
+        b.iter(|| {
+            context.synchronize();
+            context.pool.reset();
+            run_variant_per_batch::<ScaledDotProductAttentionOptimizedOp>(&mut context, batch, seq_q, seq_k, dim, causal);
             context.synchronize();
         })
     });

--- a/benches/softmax_backend_benchmark.rs
+++ b/benches/softmax_backend_benchmark.rs
@@ -1,5 +1,5 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use test_burn::metallic::kernels::softmax::{apply_softmax, METALLIC_SOFTMAX_BACKEND_ENV};
+use criterion::{Criterion, criterion_group, criterion_main};
+use test_burn::metallic::kernels::softmax::{METALLIC_SOFTMAX_BACKEND_ENV, apply_softmax};
 use test_burn::metallic::resource_cache::ResourceCache;
 use test_burn::metallic::{Context, Tensor};
 

--- a/benches/softmax_backend_benchmark.rs
+++ b/benches/softmax_backend_benchmark.rs
@@ -13,12 +13,12 @@ fn run_softmax(ctx: &mut Context, cache: Option<&mut ResourceCache>, allow_mps: 
     match cache {
         Some(cache_ref) => {
             for _ in 0..ITERATIONS {
-                let _ = apply_softmax(ctx, Some(cache_ref), &attn, ROWS, COLUMNS, false, 0, allow_mps).unwrap();
+                let _ = apply_softmax(ctx, Some(cache_ref), &attn, 1, ROWS, COLUMNS, false, 0, allow_mps).unwrap();
             }
         }
         None => {
             for _ in 0..ITERATIONS {
-                let _ = apply_softmax(ctx, None, &attn, ROWS, COLUMNS, false, 0, allow_mps).unwrap();
+                let _ = apply_softmax(ctx, None, &attn, 1, ROWS, COLUMNS, false, 0, allow_mps).unwrap();
             }
         }
     }

--- a/benches/swiglu_cache_benchmark.rs
+++ b/benches/swiglu_cache_benchmark.rs
@@ -3,7 +3,7 @@
 //! This helps quantify the benefit of sharing a [`ResourceCache`] across the individual
 //! matmul and elementwise kernels that make up the composite implementation.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use test_burn::metallic::kernels::swiglu::swiglu_with_optional_cache;
 use test_burn::metallic::resource_cache::ResourceCache;
 use test_burn::metallic::{Context, Tensor};

--- a/src/Metallic/cache_keys.rs
+++ b/src/Metallic/cache_keys.rs
@@ -12,6 +12,7 @@ pub struct MpsGemmKey {
     pub result_rows: usize,
     pub result_columns: usize,
     pub interior_columns: usize,
+    pub batch_size: usize,
     pub alpha: f32,
     pub beta: f32,
 }
@@ -23,6 +24,7 @@ impl PartialEq for MpsGemmKey {
             && self.result_rows == other.result_rows
             && self.result_columns == other.result_columns
             && self.interior_columns == other.interior_columns
+            && self.batch_size == other.batch_size
             && self.alpha == other.alpha
             && self.beta == other.beta
     }
@@ -37,6 +39,7 @@ impl Hash for MpsGemmKey {
         self.result_rows.hash(state);
         self.result_columns.hash(state);
         self.interior_columns.hash(state);
+        self.batch_size.hash(state);
         // For f32, we need to be careful about NaN values
         // We'll use the bit representation for hashing
         self.alpha.to_bits().hash(state);
@@ -52,11 +55,17 @@ pub struct MpsMatrixDescriptorKey {
     pub rows: usize,
     pub columns: usize,
     pub row_bytes: usize,
+    pub matrices: usize,
+    pub matrix_bytes: usize,
 }
 
 impl PartialEq for MpsMatrixDescriptorKey {
     fn eq(&self, other: &Self) -> bool {
-        self.rows == other.rows && self.columns == other.columns && self.row_bytes == other.row_bytes
+        self.rows == other.rows
+            && self.columns == other.columns
+            && self.row_bytes == other.row_bytes
+            && self.matrices == other.matrices
+            && self.matrix_bytes == other.matrix_bytes
     }
 }
 
@@ -67,6 +76,8 @@ impl Hash for MpsMatrixDescriptorKey {
         self.rows.hash(state);
         self.columns.hash(state);
         self.row_bytes.hash(state);
+        self.matrices.hash(state);
+        self.matrix_bytes.hash(state);
     }
 }
 

--- a/src/Metallic/cacheable_resources.rs
+++ b/src/Metallic/cacheable_resources.rs
@@ -3,9 +3,9 @@ use super::{
     cacheable::Cacheable,
     error::MetalError,
 };
+use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2::AnyThread;
 use objc2_metal::MTLDevice;
 use objc2_metal_performance_shaders::{MPSMatrixDescriptor, MPSMatrixMultiplication, MPSMatrixSoftMax};
 

--- a/src/Metallic/context.rs
+++ b/src/Metallic/context.rs
@@ -7,7 +7,7 @@ use crate::metallic::encoder::{dispatch_threadgroups, set_buffer, set_bytes, set
 use crate::metallic::kernels::softmax::{SoftmaxBackend, SoftmaxSample};
 use crate::metallic::kernels::swiglu::SwiGLUOp;
 use crate::metallic::tensor::Dtype;
-use crate::metallic::{kernels, Tensor};
+use crate::metallic::{Tensor, kernels};
 use kernels::matmul::{MatMulAlphaBetaOp, MatMulOp};
 use kernels::scaled_dot_product_attention::ScaledDotProductAttentionOptimizedOp;
 use kernels::{KernelFunction, KernelInvocable, KernelManager};

--- a/src/Metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/Metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -7,9 +7,9 @@ use objc2_metal_performance_shaders::{MPSMatrixDescriptor, MPSMatrixMultiplicati
 
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::{
+    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
-    Context, MetalError, Operation, Tensor,
 };
 
 // Public struct for matmul with alpha/beta scaling

--- a/src/Metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/Metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -1,14 +1,15 @@
 use super::*;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
+use objc2_foundation::NSUInteger;
 use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrixDescriptor, MPSMatrixMultiplication};
 
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::{
-    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
+    Context, MetalError, Operation, Tensor,
 };
 
 // Public struct for matmul with alpha/beta scaling
@@ -26,6 +27,7 @@ struct MatMulAlphaBeta {
     pub right_desc: Retained<MPSMatrixDescriptor>,
     pub result_desc: Retained<MPSMatrixDescriptor>,
     pub gemm: Retained<MPSMatrixMultiplication>,
+    pub batch_size: usize,
 }
 
 // Implement `KernelInvocable` for the public struct.
@@ -49,28 +51,22 @@ impl KernelInvocable for MatMulAlphaBetaOp {
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         let (left, right, result, transpose_left, transpose_right, alpha, beta) = args;
 
-        // Validate dimensions for matrix multiplication
-        if left.dims().len() != 2 || right.dims().len() != 2 {
-            return Err(MetalError::InvalidOperation("matmul requires 2D tensors".to_string()));
-        }
-
         ctx.prepare_tensors_for_active_cmd(&[left, right, result]);
 
-        let left_rows = left.dims()[0];
-        let left_cols = left.dims()[1];
-        let right_rows = right.dims()[0];
-        let right_cols = right.dims()[1];
+        let left_view = left.as_mps_matrix_batch_view()?;
+        let right_view = right.as_mps_matrix_batch_view()?;
+        let result_view = result.as_mps_matrix_batch_view()?;
 
         // Calculate effective dimensions based on transpose
         let (eff_left_rows, eff_left_cols) = if transpose_left {
-            (left_cols, left_rows)
+            (left_view.columns, left_view.rows)
         } else {
-            (left_rows, left_cols)
+            (left_view.rows, left_view.columns)
         };
         let (eff_right_rows, eff_right_cols) = if transpose_right {
-            (right_cols, right_rows)
+            (right_view.columns, right_view.rows)
         } else {
-            (right_rows, right_cols)
+            (right_view.rows, right_view.columns)
         };
 
         if eff_left_cols != eff_right_rows {
@@ -80,14 +76,17 @@ impl KernelInvocable for MatMulAlphaBetaOp {
             )));
         }
 
+        if left_view.batch != right_view.batch || left_view.batch != result_view.batch {
+            return Err(MetalError::InvalidOperation(
+                "Batched matmul requires consistent batch dimensions".to_string(),
+            ));
+        }
+
         // Validate result tensor dimensions match expected output dimensions
-        if result.dims()[0] != eff_left_rows || result.dims()[1] != eff_right_cols {
+        if result_view.rows != eff_left_rows || result_view.columns != eff_right_cols {
             return Err(MetalError::InvalidOperation(format!(
                 "Result tensor dimensions ({}, {}) do not match expected output dimensions ({}, {})",
-                result.dims()[0],
-                result.dims()[1],
-                eff_left_rows,
-                eff_right_cols
+                result_view.rows, result_view.columns, eff_left_rows, eff_right_cols
             )));
         }
 
@@ -98,6 +97,7 @@ impl KernelInvocable for MatMulAlphaBetaOp {
             result_rows: eff_left_rows,
             result_columns: eff_right_cols,
             interior_columns: eff_left_cols, // This is the "k" dimension after applying transpose
+            batch_size: result_view.batch,
             alpha,
             beta,
         };
@@ -107,23 +107,29 @@ impl KernelInvocable for MatMulAlphaBetaOp {
 
         // Create MPS matrix descriptors based on original dimensions (not transposed ones)
         let left_desc_key = MpsMatrixDescriptorKey {
-            rows: left_rows,
-            columns: left_cols,
-            row_bytes: left_cols * std::mem::size_of::<f32>(),
+            rows: left_view.rows,
+            columns: left_view.columns,
+            row_bytes: left_view.row_bytes,
+            matrices: left_view.batch,
+            matrix_bytes: left_view.matrix_bytes,
         };
         let left_desc = cache.get_or_create_descriptor(left_desc_key, &ctx.device)?;
 
         let right_desc_key = MpsMatrixDescriptorKey {
-            rows: right_rows,
-            columns: right_cols,
-            row_bytes: right_cols * std::mem::size_of::<f32>(),
+            rows: right_view.rows,
+            columns: right_view.columns,
+            row_bytes: right_view.row_bytes,
+            matrices: right_view.batch,
+            matrix_bytes: right_view.matrix_bytes,
         };
         let right_desc = cache.get_or_create_descriptor(right_desc_key, &ctx.device)?;
 
         let result_desc_key = MpsMatrixDescriptorKey {
             rows: eff_left_rows,
             columns: eff_right_cols,
-            row_bytes: eff_right_cols * std::mem::size_of::<f32>(),
+            row_bytes: result_view.row_bytes,
+            matrices: result_view.batch,
+            matrix_bytes: result_view.matrix_bytes,
         };
         let result_desc = cache.get_or_create_descriptor(result_desc_key, &ctx.device)?;
 
@@ -139,6 +145,7 @@ impl KernelInvocable for MatMulAlphaBetaOp {
             right_desc,
             result_desc,
             gemm,
+            batch_size: result_view.batch,
         };
 
         // Return the boxed operation and the result tensor (already provided)
@@ -160,6 +167,10 @@ impl Operation for MatMulAlphaBeta {
         let result = mps_matrix_from_buffer(&self.result_buf, self.result_offset, &self.result_desc);
 
         // Encode the MPS matrix multiplication
+        unsafe {
+            self.gemm.setBatchStart(0 as NSUInteger);
+            self.gemm.setBatchSize(self.batch_size as NSUInteger);
+        }
         encode_mps_matrix_multiplication(&self.gemm, command_buffer, &left, &right, &result);
         Ok(())
     }

--- a/src/Metallic/kernels/matmul/matmul_test.rs
+++ b/src/Metallic/kernels/matmul/matmul_test.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use crate::metallic::kernels::matmul::{MatMulAlphaBetaOp, MatMulOp, mps_matrix_from_buffer};
+use crate::metallic::kernels::matmul::{mps_matrix_from_buffer, MatMulAlphaBetaOp, MatMulOp};
 use crate::metallic::{Context, MetalError, Tensor};
 
 // Helpers

--- a/src/Metallic/kernels/matmul/matmul_test.rs
+++ b/src/Metallic/kernels/matmul/matmul_test.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use crate::metallic::kernels::matmul::{mps_matrix_from_buffer, MatMulAlphaBetaOp, MatMulOp};
+use crate::metallic::kernels::matmul::{MatMulAlphaBetaOp, MatMulOp, mps_matrix_from_buffer};
 use crate::metallic::{Context, MetalError, Tensor};
 
 // Helpers

--- a/src/Metallic/kernels/matmul/mod.rs
+++ b/src/Metallic/kernels/matmul/mod.rs
@@ -1,6 +1,6 @@
-use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
+use objc2::AnyThread;
 use objc2_foundation::NSUInteger;
 use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrix, MPSMatrixDescriptor, MPSMatrixMultiplication};
@@ -58,10 +58,10 @@ impl KernelInvocable for MatMulOp {
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         let (left, right, transpose_left, transpose_right) = args;
 
-        ctx.prepare_tensors_for_active_cmd(&[left, right]);
+        let (left_tensor, left_view) = left.ensure_mps_contiguous_batch(ctx)?;
+        let (right_tensor, right_view) = right.ensure_mps_contiguous_batch(ctx)?;
 
-        let left_view = left.as_mps_matrix_batch_view()?;
-        let right_view = right.as_mps_matrix_batch_view()?;
+        ctx.prepare_tensors_for_active_cmd(&[&left_tensor, &right_tensor]);
 
         // Calculate effective dimensions based on transpose
         let (eff_left_rows, eff_left_cols) = if transpose_left {
@@ -142,10 +142,10 @@ impl KernelInvocable for MatMulOp {
 
         // Create the internal operation struct.
         let op = MatMul {
-            left_buf: left.buf.clone(),
-            left_offset: left.offset,
-            right_buf: right.buf.clone(),
-            right_offset: right.offset,
+            left_buf: left_tensor.buf.clone(),
+            left_offset: left_tensor.offset,
+            right_buf: right_tensor.buf.clone(),
+            right_offset: right_tensor.offset,
             result_buf: out.buf.clone(),
             result_offset: out.offset,
             left_desc,

--- a/src/Metallic/kernels/matmul/mod.rs
+++ b/src/Metallic/kernels/matmul/mod.rs
@@ -1,3 +1,4 @@
+use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;

--- a/src/Metallic/kernels/matmul/mod.rs
+++ b/src/Metallic/kernels/matmul/mod.rs
@@ -1,15 +1,15 @@
+use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2::AnyThread;
 use objc2_foundation::NSUInteger;
 use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrix, MPSMatrixDescriptor, MPSMatrixMultiplication};
 
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::{
+    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
-    Context, MetalError, Operation, Tensor,
 };
 
 mod matmul_test;
@@ -41,7 +41,7 @@ struct MatMul {
 impl KernelInvocable for MatMulOp {
     // Input arguments for the call - two input tensors + transpose options
     type Args<'a> = (&'a Tensor, &'a Tensor, bool, bool); // (left, right, transpose_left, transpose_right)
-                                                          // The output type
+    // The output type
 
     // For MPS operations, return None since they don't use KernelFunction
     fn function_id() -> Option<KernelFunction> {

--- a/src/Metallic/kernels/matmul/mod.rs
+++ b/src/Metallic/kernels/matmul/mod.rs
@@ -1,14 +1,14 @@
-use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
+use objc2_foundation::NSUInteger;
 use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrix, MPSMatrixDescriptor, MPSMatrixMultiplication};
 
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::{
-    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
+    Context, MetalError, Operation, Tensor,
 };
 
 mod matmul_test;
@@ -33,13 +33,14 @@ struct MatMul {
     pub right_desc: Retained<MPSMatrixDescriptor>,
     pub result_desc: Retained<MPSMatrixDescriptor>,
     pub gemm: Retained<MPSMatrixMultiplication>,
+    pub batch_size: usize,
 }
 
 // Implement `KernelInvocable` for the public struct.
 impl KernelInvocable for MatMulOp {
     // Input arguments for the call - two input tensors + transpose options
     type Args<'a> = (&'a Tensor, &'a Tensor, bool, bool); // (left, right, transpose_left, transpose_right)
-    // The output type
+                                                          // The output type
 
     // For MPS operations, return None since they don't use KernelFunction
     fn function_id() -> Option<KernelFunction> {
@@ -56,28 +57,21 @@ impl KernelInvocable for MatMulOp {
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         let (left, right, transpose_left, transpose_right) = args;
 
-        // Validate dimensions for matrix multiplication
-        if left.dims().len() != 2 || right.dims().len() != 2 {
-            return Err(MetalError::InvalidOperation("matmul requires 2D tensors".to_string()));
-        }
-
         ctx.prepare_tensors_for_active_cmd(&[left, right]);
 
-        let left_rows = left.dims()[0];
-        let left_cols = left.dims()[1];
-        let right_rows = right.dims()[0];
-        let right_cols = right.dims()[1];
+        let left_view = left.as_mps_matrix_batch_view()?;
+        let right_view = right.as_mps_matrix_batch_view()?;
 
         // Calculate effective dimensions based on transpose
         let (eff_left_rows, eff_left_cols) = if transpose_left {
-            (left_cols, left_rows)
+            (left_view.columns, left_view.rows)
         } else {
-            (left_rows, left_cols)
+            (left_view.rows, left_view.columns)
         };
         let (eff_right_rows, eff_right_cols) = if transpose_right {
-            (right_cols, right_rows)
+            (right_view.columns, right_view.rows)
         } else {
-            (right_rows, right_cols)
+            (right_view.rows, right_view.columns)
         };
 
         if eff_left_cols != eff_right_rows {
@@ -87,9 +81,20 @@ impl KernelInvocable for MatMulOp {
             )));
         }
 
+        if left_view.batch != right_view.batch {
+            return Err(MetalError::InvalidOperation(
+                "Batched matmul requires operands to share the same batch size".to_string(),
+            ));
+        }
+
         // Create the output tensor (eff_left_rows x eff_right_cols)
-        let out_dims = vec![eff_left_rows, eff_right_cols];
+        let out_dims = if left_view.batch > 1 {
+            vec![left_view.batch, eff_left_rows, eff_right_cols]
+        } else {
+            vec![eff_left_rows, eff_right_cols]
+        };
         let out = Tensor::create_tensor_pooled(out_dims, ctx)?;
+        let result_view = out.as_mps_matrix_batch_view()?;
 
         // Get or create MPSMatrixMultiplication operation from cache
         let gemm_key = MpsGemmKey {
@@ -98,6 +103,7 @@ impl KernelInvocable for MatMulOp {
             result_rows: eff_left_rows,
             result_columns: eff_right_cols,
             interior_columns: eff_left_cols, // This is the "k" dimension after applying transpose
+            batch_size: result_view.batch,
             alpha: 1.0,
             beta: 0.0,
         };
@@ -107,23 +113,29 @@ impl KernelInvocable for MatMulOp {
 
         // Create MPS matrix descriptors based on original dimensions (not transposed ones)
         let left_desc_key = MpsMatrixDescriptorKey {
-            rows: left_rows,
-            columns: left_cols,
-            row_bytes: left_cols * std::mem::size_of::<f32>(),
+            rows: left_view.rows,
+            columns: left_view.columns,
+            row_bytes: left_view.row_bytes,
+            matrices: left_view.batch,
+            matrix_bytes: left_view.matrix_bytes,
         };
         let left_desc = cache.get_or_create_descriptor(left_desc_key, &ctx.device)?;
 
         let right_desc_key = MpsMatrixDescriptorKey {
-            rows: right_rows,
-            columns: right_cols,
-            row_bytes: right_cols * std::mem::size_of::<f32>(),
+            rows: right_view.rows,
+            columns: right_view.columns,
+            row_bytes: right_view.row_bytes,
+            matrices: right_view.batch,
+            matrix_bytes: right_view.matrix_bytes,
         };
         let right_desc = cache.get_or_create_descriptor(right_desc_key, &ctx.device)?;
 
         let result_desc_key = MpsMatrixDescriptorKey {
             rows: eff_left_rows,
             columns: eff_right_cols,
-            row_bytes: eff_right_cols * std::mem::size_of::<f32>(),
+            row_bytes: result_view.row_bytes,
+            matrices: result_view.batch,
+            matrix_bytes: result_view.matrix_bytes,
         };
         let result_desc = cache.get_or_create_descriptor(result_desc_key, &ctx.device)?;
 
@@ -139,6 +151,7 @@ impl KernelInvocable for MatMulOp {
             right_desc,
             result_desc,
             gemm,
+            batch_size: result_view.batch,
         };
 
         // Return the boxed operation and the output tensor.
@@ -160,6 +173,10 @@ impl Operation for MatMul {
         let result = mps_matrix_from_buffer(&self.result_buf, self.result_offset, &self.result_desc);
 
         // Encode the MPS matrix multiplication
+        unsafe {
+            self.gemm.setBatchStart(0 as NSUInteger);
+            self.gemm.setBatchSize(self.batch_size as NSUInteger);
+        }
         encode_mps_matrix_multiplication(&self.gemm, command_buffer, &left, &right, &result);
         Ok(())
     }
@@ -177,7 +194,16 @@ pub fn mps_matrix_from_buffer(
     offset: usize,
     descriptor: &Retained<MPSMatrixDescriptor>,
 ) -> Retained<MPSMatrix> {
-    let size = unsafe { descriptor.rowBytes() * descriptor.rows() };
+    let rows = unsafe { descriptor.rows() };
+    let row_bytes = unsafe { descriptor.rowBytes() };
+    let matrices = unsafe { descriptor.matrices() };
+    let total_bytes = if matrices <= 1 {
+        row_bytes * rows
+    } else {
+        let matrix_bytes = unsafe { descriptor.matrixBytes() };
+        (matrices - 1) * matrix_bytes + rows * row_bytes
+    };
+    let size = total_bytes;
     debug_assert!(offset + size <= buffer.length(), "matrix dimensions exceed buffer length");
     unsafe { MPSMatrix::initWithBuffer_offset_descriptor(MPSMatrix::alloc(), buffer, offset, descriptor) }
 }

--- a/src/Metallic/kernels/scaled_dot_product_attention/mod.rs
+++ b/src/Metallic/kernels/scaled_dot_product_attention/mod.rs
@@ -5,9 +5,9 @@ use objc2_metal::{MTLCommandBuffer, MTLComputePipelineState};
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::kernels::matmul::mps_matrix_from_buffer;
 use crate::metallic::{
+    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsMatrixDescriptorKey, MpsSoftMaxKey},
     resource_cache::ResourceCache,
-    Context, MetalError, Operation, Tensor,
 };
 
 use std::mem::size_of;
@@ -171,7 +171,7 @@ fn create_sdpa_operation(
         )?
     };
 
-    match cache.as_deref_mut() {
+    match cache {
         Some(cache_ref) => {
             ctx.matmul_alpha_beta_with_cache(&softmax_result, v, &out, false, false, 1.0, 0.0, cache_ref)?;
         }

--- a/src/Metallic/kernels/softmax/softmax_test.rs
+++ b/src/Metallic/kernels/softmax/softmax_test.rs
@@ -35,11 +35,7 @@ fn cpu_softmax(input: &[f32], seq_q: usize, seq_k: usize, causal: bool) -> Vec<f
 }
 
 fn softmax_rows_total(attn_tensor: &Tensor, seq_k: usize) -> u32 {
-    if seq_k == 0 {
-        0
-    } else {
-        (attn_tensor.len() / seq_k) as u32
-    }
+    if seq_k == 0 { 0 } else { (attn_tensor.len() / seq_k) as u32 }
 }
 
 #[test]

--- a/src/Metallic/kernels/softmax/softmax_test.rs
+++ b/src/Metallic/kernels/softmax/softmax_test.rs
@@ -34,6 +34,14 @@ fn cpu_softmax(input: &[f32], seq_q: usize, seq_k: usize, causal: bool) -> Vec<f
     output
 }
 
+fn softmax_rows_total(attn_tensor: &Tensor, seq_k: usize) -> u32 {
+    if seq_k == 0 {
+        0
+    } else {
+        (attn_tensor.len() / seq_k) as u32
+    }
+}
+
 #[test]
 fn test_softmax_golden_non_causal() -> Result<(), MetalError> {
     let mut context = Context::new()?;
@@ -46,7 +54,14 @@ fn test_softmax_golden_non_causal() -> Result<(), MetalError> {
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
     // Apply softmax using the new kernel system (in-place operation)
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -96,7 +111,14 @@ fn test_softmax_golden_causal() -> Result<(), MetalError> {
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true);
 
     // Apply softmax using the new kernel system (in-place operation) with causal masking
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        1,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -167,7 +189,14 @@ fn test_softmax_extremes_large_positive_values() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -234,7 +263,14 @@ fn test_softmax_extremes_large_negative_values() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -301,7 +337,14 @@ fn test_softmax_extremes_identical_values() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -383,7 +426,14 @@ fn test_softmax_extremes_single_large_outlier() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -467,7 +517,14 @@ fn test_softmax_extremes_causal_with_extremes() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        1,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -598,7 +655,14 @@ fn test_softmax_extremes_underflow_scenarios() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -674,7 +738,14 @@ fn test_softmax_extremes_infinity_scenarios() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -761,7 +832,14 @@ fn test_softmax_extremes_nan_scenarios() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -811,7 +889,14 @@ fn test_softmax_extremes_large_sequences() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -880,7 +965,14 @@ fn test_softmax_extremes_very_large_positive_and_negative_mixed() -> Result<(), 
 
     let cpu_output = cpu_softmax_with_infinity(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -947,7 +1039,14 @@ fn test_softmax_irregular_sizes_1() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -997,7 +1096,14 @@ fn test_softmax_irregular_sizes_2() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, false);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -1047,7 +1153,14 @@ fn test_softmax_causal_irregular_sizes() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true);
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        1,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -1112,7 +1225,14 @@ fn test_softmax_causal_large_irregular() -> Result<(), MetalError> {
 
     let cpu_output = cpu_softmax(&input_data, seq_q, seq_k, true); // Using causal=true
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 1, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        1,
+        0,
+    ))?;
     context.synchronize();
 
     let metal_output = result.as_slice();
@@ -1191,7 +1311,14 @@ fn test_softmax_threadgroup_execution_width() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1226,7 +1353,14 @@ fn test_softmax_threadgroup_large_seq_k() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1261,7 +1395,14 @@ fn test_softmax_threadgroup_very_large_seq_k() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1296,7 +1437,14 @@ fn test_softmax_threadgroup_multiple_rows() -> Result<(), MetalError> {
     let input_tensor = Tensor::create_tensor_from_slice(&input_data, vec![seq_q, seq_k], &context)?; // Reshape to 2D as expected by kernel
     let attn_tensor = input_tensor.clone();
 
-    let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0))?;
+    let result = context.call::<SoftmaxOp>((
+        &attn_tensor,
+        softmax_rows_total(&attn_tensor, seq_k),
+        seq_q as u32,
+        seq_k as u32,
+        0,
+        0,
+    ))?;
     context.synchronize();
 
     // Verify the operation completed successfully
@@ -1327,7 +1475,7 @@ fn test_softmax_logic() -> Result<(), MetalError> {
     let input_data = vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0]; // Two rows to softmax independently
     let attn = Tensor::create_tensor_from_slice(&input_data, vec![2, 3], &ctx)?;
     // Apply softmax with no causal masking (causal=0)
-    let result = ctx.call::<SoftmaxOp>((&attn, 2, 3, 0, 0))?;
+    let result = ctx.call::<SoftmaxOp>((&attn, softmax_rows_total(&attn, 3), 2, 3, 0, 0))?;
     // Check that each row sums to approximately 1 (property of softmax)
     let result_slice = result.as_slice();
     let row1_sum: f32 = result_slice[0..3].iter().sum();

--- a/src/Metallic/models/qwen25/loading.rs
+++ b/src/Metallic/models/qwen25/loading.rs
@@ -497,7 +497,6 @@ impl LoadableModel for super::Qwen25 {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::pack_weight_transposed_into_fused_slice;

--- a/src/Metallic/models/tests.rs
+++ b/src/Metallic/models/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use super::*;
-use crate::metallic::{resource_cache::ResourceCache, Operation};
 use crate::metallic::{Context, MetalError};
+use crate::metallic::{Operation, resource_cache::ResourceCache};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_metal::{MTLCommandBuffer, MTLCommandEncoder as _};

--- a/src/Metallic/resource_cache.rs
+++ b/src/Metallic/resource_cache.rs
@@ -71,12 +71,7 @@ impl ResourceCache {
         key: MpsGemmKey,
         device: &Retained<ProtocolObject<dyn MTLDevice>>,
     ) -> Result<Retained<objc2_metal_performance_shaders::MPSMatrixMultiplication>, MetalError> {
-        let cacheable_gemm = Self::get_or_create_resource(
-            &mut self.gemm_cache,
-            key,
-            Some(device),
-            self.default_device.as_ref(),
-        )?;
+        let cacheable_gemm = Self::get_or_create_resource(&mut self.gemm_cache, key, Some(device), self.default_device.as_ref())?;
         Ok(cacheable_gemm.gemm.clone())
     }
 
@@ -86,12 +81,8 @@ impl ResourceCache {
         key: MpsMatrixDescriptorKey,
         device: &Retained<ProtocolObject<dyn MTLDevice>>,
     ) -> Result<Retained<objc2_metal_performance_shaders::MPSMatrixDescriptor>, MetalError> {
-        let cacheable_descriptor = Self::get_or_create_resource(
-            &mut self.descriptor_cache,
-            key,
-            Some(device),
-            self.default_device.as_ref(),
-        )?;
+        let cacheable_descriptor =
+            Self::get_or_create_resource(&mut self.descriptor_cache, key, Some(device), self.default_device.as_ref())?;
         Ok(cacheable_descriptor.descriptor.clone())
     }
 
@@ -101,12 +92,7 @@ impl ResourceCache {
         key: MpsSoftMaxKey,
         device: &Retained<ProtocolObject<dyn MTLDevice>>,
     ) -> Result<Retained<objc2_metal_performance_shaders::MPSMatrixSoftMax>, MetalError> {
-        let cacheable_softmax = Self::get_or_create_resource(
-            &mut self.softmax_cache,
-            key,
-            Some(device),
-            self.default_device.as_ref(),
-        )?;
+        let cacheable_softmax = Self::get_or_create_resource(&mut self.softmax_cache, key, Some(device), self.default_device.as_ref())?;
         Ok(cacheable_softmax.softmax.clone())
     }
 
@@ -114,14 +100,9 @@ impl ResourceCache {
     pub fn get_or_create_sdpa(&mut self, batch: usize, seq_q: usize, seq_k: usize, dim: usize) -> CacheableSdpa {
         let key = SdpaKey { batch, seq_q, seq_k, dim };
         // SDPA creation should never fail, so we unwrap.
-        Self::get_or_create_resource(
-            &mut self.sdpa_cache,
-            key,
-            None,
-            self.default_device.as_ref(),
-        )
-        .unwrap()
-        .clone()
+        Self::get_or_create_resource(&mut self.sdpa_cache, key, None, self.default_device.as_ref())
+            .unwrap()
+            .clone()
     }
 
     /// Get statistics about the cache.

--- a/src/Metallic/tests/determinism_test.rs
+++ b/src/Metallic/tests/determinism_test.rs
@@ -1,11 +1,7 @@
 use super::*;
 
 fn softmax_rows_total(attn_tensor: &Tensor, seq_k: usize) -> u32 {
-    if seq_k == 0 {
-        0
-    } else {
-        (attn_tensor.len() / seq_k) as u32
-    }
+    if seq_k == 0 { 0 } else { (attn_tensor.len() / seq_k) as u32 }
 }
 
 #[test]

--- a/src/Metallic/tests/error_path_test.rs
+++ b/src/Metallic/tests/error_path_test.rs
@@ -228,7 +228,8 @@ fn test_softmax_invalid_dimensions() {
     let result = Tensor::create_tensor_from_slice(&input_data, dims, &context);
     // This might fail at tensor creation time
     if let Ok(attn_tensor) = result {
-        let result = context.call::<SoftmaxOp>((&attn_tensor, seq_q as u32, seq_k as u32, 0, 0));
+        let rows_total = if seq_k == 0 { 0 } else { (attn_tensor.len() / seq_k) as u32 };
+        let result = context.call::<SoftmaxOp>((&attn_tensor, rows_total, seq_q as u32, seq_k as u32, 0, 0));
         // Should not panic, but might return an error
         assert!(result.is_ok() || result.is_err());
     }

--- a/src/Metallic/tests/error_path_test.rs
+++ b/src/Metallic/tests/error_path_test.rs
@@ -90,6 +90,7 @@ fn test_matmul_invalid_shapes() {
         result_rows: m,
         result_columns: n,
         interior_columns: k1, // This won't match k2
+        batch_size: 1,
         alpha: 1.0,
         beta: 0.0,
     };


### PR DESCRIPTION
## Summary
- add strided MPS matrix view helpers and extend cache keys so GEMM descriptors capture batch layout
- configure matmul and softmax kernels to program MPS batch parameters and use a single batched SDPA matmul path
- expand SDPA and softmax benchmarks to compare batched execution with the legacy per-batch loop

## Testing
- not run (Metal/MPS unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d99561fc488326b20d6f0aadb41cd8