### PR TITLE
Unify tensor creation behind Tensor::new

### DIFF
--- a/KERNELS.md
+++ b/KERNELS.md
@@ -188,13 +188,13 @@ To maintain quality, add a test file for your new kernel.
     ```rust
     #![cfg(test)]
     use crate::metallic::kernels::my_kernel::MyKernelOp;
-    use crate::metallic::{Context, Tensor};
+    use crate::metallic::{Context, Tensor, TensorInit, TensorStorage};
 
     #[test]
     fn test_my_kernel_logic() -> Result<(), MetalError> {
         let mut ctx = Context::new()?;
-        let a = Tensor::create_tensor_from_slice(&[1., 2.], vec![2], &ctx)?;
-        let b = Tensor::create_tensor_from_slice(&[3., 4.], vec![2], &ctx)?;
+        let a = Tensor::new(vec![2], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&[1., 2.]))?;
+        let b = Tensor::new(vec![2], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&[3., 4.]))?;
 
         // Use the kernel via the generic `call` method.
         let result_tensor = ctx.call::<MyKernelOp>((a, b))?;

--- a/src/Metallic/context.rs
+++ b/src/Metallic/context.rs
@@ -7,7 +7,7 @@ use crate::metallic::encoder::{dispatch_threadgroups, set_buffer, set_bytes, set
 use crate::metallic::kernels::softmax::{SoftmaxBackend, SoftmaxSample};
 use crate::metallic::kernels::swiglu::SwiGLUOp;
 use crate::metallic::tensor::Dtype;
-use crate::metallic::{Tensor, kernels};
+use crate::metallic::{Tensor, kernels, TensorInit, TensorStorage};
 use kernels::matmul::{MatMulAlphaBetaOp, MatMulOp};
 use kernels::scaled_dot_product_attention::ScaledDotProductAttentionOptimizedOp;
 use kernels::{KernelFunction, KernelInvocable, KernelManager};
@@ -275,9 +275,9 @@ impl Context {
         let bias = fused_bias.clone();
         self.prepare_tensors_for_active_cmd(&[&linear, &bias]);
 
-        let q_out = Tensor::create_tensor_pooled(vec![m, d_model], self)?;
-        let k_out = Tensor::create_tensor_pooled(vec![m, kv_dim], self)?;
-        let v_out = Tensor::create_tensor_pooled(vec![m, kv_dim], self)?;
+        let q_out = Tensor::new(vec![m, d_model], TensorStorage::Pooled(self), TensorInit::Uninitialized)?;
+        let k_out = Tensor::new(vec![m, kv_dim], TensorStorage::Pooled(self), TensorInit::Uninitialized)?;
+        let v_out = Tensor::new(vec![m, kv_dim], TensorStorage::Pooled(self), TensorInit::Uninitialized)?;
 
         self.prepare_tensors_for_active_cmd(&[&q_out, &k_out, &v_out]);
 

--- a/src/Metallic/kernels/elemwise_add/elemwise_add_test.rs
+++ b/src/Metallic/kernels/elemwise_add/elemwise_add_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::elemwise_add::elemwise_add::ElemwiseAddOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 fn cpu_elemwise_add(a: &[f32], b: &[f32]) -> Vec<f32> {
     a.iter().zip(b.iter()).map(|(x, y)| x + y).collect()
@@ -13,8 +13,8 @@ fn test_elemwise_add_basic() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
     let b_data = vec![0.5, 1.5, 2.5, 3.5];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_add(&a_data, &b_data);
 
@@ -35,8 +35,8 @@ fn test_elemwise_add_1d() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_data = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![6], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![6], &context)?;
+    let a_tensor = Tensor::new(vec![6], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![6], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_add(&a_data, &b_data);
 
@@ -57,8 +57,8 @@ fn test_elemwise_add_3d() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let b_data = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_add(&a_data, &b_data);
 
@@ -80,8 +80,8 @@ fn test_elemwise_add_large_tensor() -> Result<(), MetalError> {
     let a_data: Vec<f32> = (0..size).map(|i| i as f32 * 0.5).collect();
     let b_data: Vec<f32> = (0..size).map(|i| i as f32 * 0.3).collect();
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![32, 32], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![32, 32], &context)?;
+    let a_tensor = Tensor::new(vec![32, 32], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![32, 32], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_add(&a_data, &b_data);
 

--- a/src/Metallic/kernels/elemwise_add/elemwise_broadcast_add.rs
+++ b/src/Metallic/kernels/elemwise_add/elemwise_broadcast_add.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 // User-facing struct for the broadcast element-wise add operation.
 pub struct BroadcastElemwiseAddOp;
@@ -36,7 +37,7 @@ impl KernelInvocable for BroadcastElemwiseAddOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
-        let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
+        let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let op = BroadcastElemwiseAdd {
             a,
             b,

--- a/src/Metallic/kernels/elemwise_add/elemwise_broadcast_add_test.rs
+++ b/src/Metallic/kernels/elemwise_add/elemwise_broadcast_add_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::elemwise_add::elemwise_broadcast_add::BroadcastElemwiseAddOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 fn cpu_broadcast_add(a: &[f32], b: &[f32]) -> Vec<f32> {
     a.iter().enumerate().map(|(i, x)| x + b[i % b.len()]).collect()
@@ -13,8 +13,8 @@ fn test_broadcast_add_1d_bias() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // Shape [2, 3]
     let b_data = vec![0.5, 1.0, 1.5]; // Shape [3] - broadcast along last dimension
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 3], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![3], &context)?;
+    let a_tensor = Tensor::new(vec![2, 3], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![3], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_broadcast_add(&a_data, &b_data);
 
@@ -35,8 +35,8 @@ fn test_broadcast_add_2d_bias() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]; // Shape [2, 2, 3]
     let b_data = vec![0.5, 1.0, 1.5]; // Shape [3] - broadcast along last dimension
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2, 3], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![3], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2, 3], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![3], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_broadcast_add(&a_data, &b_data);
 
@@ -57,8 +57,8 @@ fn test_broadcast_add_singleton_broadcast() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0]; // Shape [4]
     let b_data = vec![2.5]; // Shape [1] - broadcast to all elements
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![4], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![1], &context)?;
+    let a_tensor = Tensor::new(vec![4], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![1], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_broadcast_add(&a_data, &b_data);
 

--- a/src/Metallic/kernels/elemwise_add/mod.rs
+++ b/src/Metallic/kernels/elemwise_add/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 // Additional Operations for this Metal Kernel (additional functions in the kernel)
 mod elemwise_broadcast_add;
@@ -41,7 +42,7 @@ impl KernelInvocable for ElemwiseAddOp {
             )));
         }
         ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
-        let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
+        let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let op = ElemwiseAdd {
             a,
             b,

--- a/src/Metallic/kernels/elemwise_div/elemwise_div_test.rs
+++ b/src/Metallic/kernels/elemwise_div/elemwise_div_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use super::elemwise_div::ElemwiseDivOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 fn cpu_elemwise_div(a: &[f32], b: &[f32]) -> Vec<f32> {
     a.iter().zip(b.iter()).map(|(x, y)| x / y).collect()
@@ -13,8 +13,8 @@ fn test_elemwise_div_basic() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
     let b_data = vec![0.5, 1.0, 1.5, 2.0];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 
@@ -35,8 +35,8 @@ fn test_elemwise_div_1d() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let b_data = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![6], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![6], &context)?;
+    let a_tensor = Tensor::new(vec![6], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![6], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 
@@ -57,8 +57,8 @@ fn test_elemwise_div_3d() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let b_data = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 
@@ -79,8 +79,8 @@ fn test_elemwise_div_by_one() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
     let b_data = vec![1.0, 1.0, 1.0, 1.0]; // Dividing by 1 should leave values unchanged
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 
@@ -101,8 +101,8 @@ fn test_elemwise_div_with_fractions() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
     let b_data = vec![2.0, 4.0, 6.0, 8.0];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 
@@ -135,8 +135,8 @@ fn test_elemwise_div_large_tensor() -> Result<(), MetalError> {
     let a_data: Vec<f32> = (1..=size).map(|i| i as f32 * 0.5).collect();
     let b_data: Vec<f32> = (1..=size).map(|i| i as f32 * 0.3).collect();
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![32, 32], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![32, 32], &context)?;
+    let a_tensor = Tensor::new(vec![32, 32], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![32, 32], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 
@@ -170,8 +170,8 @@ fn test_elemwise_div_floating_precision() -> Result<(), MetalError> {
     let a_data = vec![1.1, 2.2, 3.3, 4.4];
     let b_data = vec![0.1, 0.2, 0.3, 0.4];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_div(&a_data, &b_data);
 

--- a/src/Metallic/kernels/elemwise_div/mod.rs
+++ b/src/Metallic/kernels/elemwise_div/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct ElemwiseDivOp;
 
@@ -35,7 +36,7 @@ impl KernelInvocable for ElemwiseDivOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
-        let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
+        let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = ElemwiseDiv {
             a,

--- a/src/Metallic/kernels/elemwise_mul/elemwise_mul_test.rs
+++ b/src/Metallic/kernels/elemwise_mul/elemwise_mul_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::elemwise_mul::ElemwiseMulOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 fn cpu_elemwise_mul(a: &[f32], b: &[f32]) -> Vec<f32> {
     a.iter().zip(b.iter()).map(|(x, y)| x * y).collect()
@@ -13,8 +13,8 @@ fn test_elemwise_mul_basic() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
     let b_data = vec![0.5, 1.5, 2.5, 3.5];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_mul(&a_data, &b_data);
 

--- a/src/Metallic/kernels/elemwise_mul/mod.rs
+++ b/src/Metallic/kernels/elemwise_mul/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct ElemwiseMulOp;
 
@@ -35,7 +36,7 @@ impl KernelInvocable for ElemwiseMulOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
-        let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
+        let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = ElemwiseMul {
             a,

--- a/src/Metallic/kernels/elemwise_sub/elemwise_sub_test.rs
+++ b/src/Metallic/kernels/elemwise_sub/elemwise_sub_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::elemwise_sub::ElemwiseSubOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 fn cpu_elemwise_sub(a: &[f32], b: &[f32]) -> Vec<f32> {
     a.iter().zip(b.iter()).map(|(x, y)| x - y).collect()
@@ -13,8 +13,8 @@ fn test_elemwise_sub_basic() -> Result<(), MetalError> {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
     let b_data = vec![0.5, 1.5, 2.5, 3.5];
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![2, 2], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![2, 2], &context)?;
+    let a_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![2, 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
 
     let cpu_result = cpu_elemwise_sub(&a_data, &b_data);
 

--- a/src/Metallic/kernels/elemwise_sub/mod.rs
+++ b/src/Metallic/kernels/elemwise_sub/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct ElemwiseSubOp;
 
@@ -35,7 +36,7 @@ impl KernelInvocable for ElemwiseSubOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
 
-        let out = Tensor::create_tensor_pooled(a.dims().to_vec(), ctx)?;
+        let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = ElemwiseSub {
             a,

--- a/src/Metallic/kernels/gelu/gelu_test.rs
+++ b/src/Metallic/kernels/gelu/gelu_test.rs
@@ -1,12 +1,12 @@
 #![cfg(test)]
 use crate::metallic::kernels::gelu::GeluOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 #[test]
 fn test_gelu_logic() -> Result<(), MetalError> {
     let mut ctx = Context::new()?;
     let input_data = vec![-1.0, 0.0, 1.0, 2.0];
-    let input = Tensor::create_tensor_from_slice(&input_data, vec![4], &ctx)?;
+    let input = Tensor::new(vec![4], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
 
     // Use the kernel via the generic `call` method.
     let result_tensor = ctx.call::<GeluOp>(input)?;
@@ -47,7 +47,7 @@ fn test_gelu_basic() -> Result<(), MetalError> {
 
     let input_data = vec![-2.0, -1.0, 0.0, 1.0, 2.0, -0.5, 0.5, 1.5, -1.5, 0.1];
     let dims = vec![2, 5];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let output_tensor = context.call::<GeluOp>(input_tensor)?;
     context.synchronize();
@@ -84,7 +84,7 @@ fn test_gelu_extremes() -> Result<(), MetalError> {
 
     let input_data = vec![-10.0, -5.0, -1.0, 0.0, 1.0, 5.0, 10.0, -100.0, 100.0, 0.001, -0.001];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let output_tensor = context.call::<GeluOp>(input_tensor)?;
     context.synchronize();
@@ -131,7 +131,7 @@ fn test_gelu_zero_and_symmetry() -> Result<(), MetalError> {
     // Test points around zero and check basic properties
     let input_data = vec![-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let output_tensor = context.call::<GeluOp>(input_tensor)?;
     context.synchronize();
@@ -173,7 +173,7 @@ fn test_gelu_validation_errors() {
     let mut context = Context::new().unwrap();
 
     let dims = vec![2, 3];
-    let input = Tensor::create_tensor(dims.clone(), &context).unwrap();
+    let input = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::Uninitialized).unwrap();
 
     // The new kernel system handles validation at the call site automatically
     // This test is now implicitly covered through the kernel system

--- a/src/Metallic/kernels/gelu/mod.rs
+++ b/src/Metallic/kernels/gelu/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct GeluOp;
 
@@ -24,7 +25,7 @@ impl KernelInvocable for GeluOp {
         let input = input;
         ctx.prepare_tensors_for_active_cmd(&[&input]);
 
-        let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
+        let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = Gelu {
             input,

--- a/src/Metallic/kernels/kv_rearrange/mod.rs
+++ b/src/Metallic/kernels/kv_rearrange/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 /// Public, user-facing, zero-sized struct for the KV rearrange operation.
 pub struct KvRearrangeOp;
@@ -39,7 +40,7 @@ impl KernelInvocable for KvRearrangeOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&input]);
 
-        let output = Tensor::create_tensor_pooled(output_dims, ctx)?;
+        let output = Tensor::new(output_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = KvRearrange {
             input,
@@ -105,7 +106,7 @@ mod kv_rearrange_test {
         let mut ctx = Context::new()?;
         // Create a simple test tensor [batch*seq, kv_dim] = [2*3, 4] = [6, 4]
         let input_data: Vec<f32> = (0..24).map(|i| i as f32).collect();
-        let input = Tensor::create_tensor_from_slice(&input_data, vec![6, 4], &ctx)?;
+        let input = Tensor::new(vec![6, 4], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
 
         // Test parameters: kv_dim=4, kv_head_dim=2, n_heads=2, n_kv_heads=1, head_dim=2, seq=3
         let result = ctx.call::<KvRearrangeOp>((input, 4, 2, 2, 1, 2, 3))?;

--- a/src/Metallic/kernels/layernorm/mod.rs
+++ b/src/Metallic/kernels/layernorm/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 /// Public, user-facing, zero-sized struct for the LayerNorm operation.
 pub struct LayerNormOp;
@@ -53,7 +54,7 @@ impl KernelInvocable for LayerNormOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&input, &gamma, &beta]);
 
-        let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
+        let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = LayerNorm {
             input,
@@ -113,13 +114,13 @@ mod layernorm_test {
         let mut ctx = Context::new()?;
         // Create test data: [2, 3] tensor, so feature_dim=3
         let input_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let input = Tensor::create_tensor_from_slice(&input_data, vec![2, 3], &ctx)?;
+        let input = Tensor::new(vec![2, 3], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
 
         // Create gamma and beta with all ones and zeros for simple test
         let gamma_data = vec![1.0, 1.0, 1.0];
-        let gamma = Tensor::create_tensor_from_slice(&gamma_data, vec![3], &ctx)?;
+        let gamma = Tensor::new(vec![3], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&gamma_data))?;
         let beta_data = vec![0.0, 0.0, 0.0];
-        let beta = Tensor::create_tensor_from_slice(&beta_data, vec![3], &ctx)?;
+        let beta = Tensor::new(vec![3], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&beta_data))?;
 
         let result = ctx.call::<LayerNormOp>((input, gamma, beta, 3))?;
 

--- a/src/Metallic/kernels/matmul/matmul_alpha_beta_test.rs
+++ b/src/Metallic/kernels/matmul/matmul_alpha_beta_test.rs
@@ -1,3 +1,4 @@
+use crate::metallic::{TensorInit, TensorStorage};
 #![cfg(test)]
 use super::*;
 
@@ -12,9 +13,9 @@ fn test_matmul_alpha_beta_accumulation() -> Result<(), MetalError> {
     let b_data = vec![7.0, 8.0, 9.0, 1.0, 2.0, 3.0]; // 3x2 matrix
     let c_data = vec![0.5, 1.5, 2.5, 3.5]; // 2x2 matrix (will be used as result with beta)
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![m, k], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![k, n], &context)?;
-    let c_tensor = Tensor::create_tensor_from_slice(&c_data, vec![m, n], &context)?; // Will be used as result with beta
+    let a_tensor = Tensor::new(vec![m, k], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![k, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
+    let c_tensor = Tensor::new(vec![m, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&c_data))?; // Will be used as result with beta
 
     let alpha = 0.5;
     let beta = 0.25;
@@ -69,9 +70,9 @@ fn test_matmul_alpha_beta_with_different_values() -> Result<(), MetalError> {
     let b_data: Vec<f32> = (0..(k * n)).map(|i| (i as f32) * 0.3).collect();
     let c_data: Vec<f32> = (0..(m * n)).map(|i| (i as f32) * 0.1).collect();
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![m, k], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![k, n], &context)?;
-    let c_tensor = Tensor::create_tensor_from_slice(&c_data, vec![m, n], &context)?;
+    let a_tensor = Tensor::new(vec![m, k], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![k, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
+    let c_tensor = Tensor::new(vec![m, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&c_data))?;
 
     let alpha = 2.0;
     let beta = -0.5;
@@ -128,9 +129,9 @@ fn test_matmul_alpha_zero_beta_one() -> Result<(), MetalError> {
     let b_data = vec![5.0, 6.0, 7.0, 8.0];
     let c_data = vec![10.0, 20.0, 30.0, 40.0]; // This should be the result when alpha=0, beta=1
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![m, k], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![k, n], &context)?;
-    let c_tensor = Tensor::create_tensor_from_slice(&c_data, vec![m, n], &context)?;
+    let a_tensor = Tensor::new(vec![m, k], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![k, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
+    let c_tensor = Tensor::new(vec![m, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&c_data))?;
 
     let alpha = 0.0;
     let beta = 1.0;
@@ -181,9 +182,9 @@ fn test_matmul_alpha_one_beta_zero() -> Result<(), MetalError> {
     let b_data = vec![5.0, 6.0, 7.0, 8.0];
     let c_data = vec![0.0, 0.0, 0.0, 0.0]; // This will be overwritten when alpha=1, beta=0
 
-    let a_tensor = Tensor::create_tensor_from_slice(&a_data, vec![m, k], &context)?;
-    let b_tensor = Tensor::create_tensor_from_slice(&b_data, vec![k, n], &context)?;
-    let c_tensor = Tensor::create_tensor_from_slice(&c_data, vec![m, n], &context)?;
+    let a_tensor = Tensor::new(vec![m, k], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&a_data))?;
+    let b_tensor = Tensor::new(vec![k, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&b_data))?;
+    let c_tensor = Tensor::new(vec![m, n], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&c_data))?;
 
     let alpha = 1.0;
     let beta = 0.0;

--- a/src/Metallic/kernels/matmul/mod.rs
+++ b/src/Metallic/kernels/matmul/mod.rs
@@ -7,9 +7,14 @@ use objc2_metal_performance_shaders::{MPSMatrix, MPSMatrixDescriptor, MPSMatrixM
 
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::{
-    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
+    Context,
+    MetalError,
+    Operation,
+    Tensor,
+    TensorInit,
+    TensorStorage,
 };
 
 mod matmul_test;
@@ -94,7 +99,7 @@ impl KernelInvocable for MatMulOp {
         } else {
             vec![eff_left_rows, eff_right_cols]
         };
-        let out = Tensor::create_tensor_pooled(out_dims, ctx)?;
+        let out = Tensor::new(out_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let result_view = out.as_mps_matrix_batch_view()?;
 
         // Get or create MPSMatrixMultiplication operation from cache

--- a/src/Metallic/kernels/permute/mod.rs
+++ b/src/Metallic/kernels/permute/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use objc2_metal::MTLResource;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct PermuteOp;
 
@@ -50,7 +51,7 @@ impl KernelInvocable for PermuteOp {
         ctx.prepare_tensors_for_active_cmd(&[&src]);
 
         // Create the output tensor
-        let dst = Tensor::create_tensor_pooled(out_dims, ctx)?;
+        let dst = Tensor::new(out_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         // Validate that input and output tensors have the same number of elements
         if src.len() != dst.len() {

--- a/src/Metallic/kernels/permute/permute_test.rs
+++ b/src/Metallic/kernels/permute/permute_test.rs
@@ -1,13 +1,13 @@
 #![cfg(test)]
 use crate::metallic::kernels::permute::PermuteOp;
-use crate::metallic::{Context, Tensor};
+use crate::metallic::{Context, Tensor, TensorInit, TensorStorage};
 
 #[test]
 fn test_permute_2d_transpose() -> Result<(), crate::metallic::MetalError> {
     let mut ctx = Context::new()?;
     // Create a 2x3 tensor: [[1, 2, 3], [4, 5, 6]]
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let src = Tensor::create_tensor_from_slice(&data, vec![2, 3], &ctx)?;
+    let src = Tensor::new(vec![2, 3], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&data))?;
 
     // Permute dimensions [1, 0] to transpose: [[1, 4], [2, 5], [3, 6]]
     let permute_indices = vec![1, 0];
@@ -24,7 +24,7 @@ fn test_permute_3d() -> Result<(), crate::metallic::MetalError> {
     let mut ctx = Context::new()?;
     // Create a 2x2x2 tensor
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    let src = Tensor::create_tensor_from_slice(&data, vec![2, 2, 2], &ctx)?;
+    let src = Tensor::new(vec![2, 2, 2], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&data))?;
 
     // Permute dimensions [2, 0, 1]
     let permute_indices = vec![2, 0, 1];
@@ -40,7 +40,7 @@ fn test_permute_identity() -> Result<(), crate::metallic::MetalError> {
     let mut ctx = Context::new()?;
     // Create a 2x3 tensor: [[1, 2, 3], [4, 5, 6]]
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let src = Tensor::create_tensor_from_slice(&data, vec![2, 3], &ctx)?;
+    let src = Tensor::new(vec![2, 3], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&data))?;
 
     // Permute with identity: [0, 1] - should be unchanged
     let permute_indices = vec![0, 1];

--- a/src/Metallic/kernels/repeat_kv_heads/mod.rs
+++ b/src/Metallic/kernels/repeat_kv_heads/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct RepeatKvHeadsOp;
 
@@ -97,7 +98,7 @@ impl KernelInvocable for RepeatKvHeadsOp {
         ctx.prepare_tensors_for_active_cmd(&[&input]);
 
         let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];
-        let output = Tensor::create_tensor_pooled(output_dims, ctx)?;
+        let output = Tensor::new(output_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let total_elements = output.len() as u32;
 
         let op = RepeatKvHeads {

--- a/src/Metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
+++ b/src/Metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
@@ -1,3 +1,4 @@
+use crate::metallic::{TensorInit, TensorStorage};
 #![cfg(test)]
 
 use super::*;
@@ -43,7 +44,7 @@ fn test_repeat_kv_heads_kernel_matches_cpu() -> Result<(), MetalError> {
 
     let element_count = batch * n_kv_heads * seq * head_dim;
     let input_data: Vec<f32> = (0..element_count).map(|v| v as f32).collect();
-    let input = Tensor::create_tensor_from_slice(&input_data, vec![batch * n_kv_heads, seq, head_dim], &ctx)?;
+    let input = Tensor::new(vec![batch * n_kv_heads, seq, head_dim], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
 
     let expected = cpu_repeat_kv_heads(&input_data, group_size, batch, n_kv_heads, n_heads, seq, head_dim);
 
@@ -94,8 +95,8 @@ fn test_incremental_repeated_cache_matches_kernel() -> Result<(), MetalError> {
             }
         }
 
-        let k_step = Tensor::create_tensor_from_slice(&k_values, vec![batch * n_kv_heads, 1, head_dim], &ctx)?;
-        let v_step = Tensor::create_tensor_from_slice(&v_values, vec![batch * n_kv_heads, 1, head_dim], &ctx)?;
+        let k_step = Tensor::new(vec![batch * n_kv_heads, 1, head_dim], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&k_values))?;
+        let v_step = Tensor::new(vec![batch * n_kv_heads, 1, head_dim], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&v_values))?;
 
         ctx.write_kv_step(layer_idx, step, &k_step, &v_step)?;
         ctx.write_repeated_kv_step(layer_idx, step, group_size, &k_step, &v_step)?;

--- a/src/Metallic/kernels/rmsnorm/mod.rs
+++ b/src/Metallic/kernels/rmsnorm/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 pub struct RMSNormOp;
 
@@ -43,7 +44,7 @@ impl KernelInvocable for RMSNormOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&input, &gamma]);
 
-        let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
+        let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = RMSNorm {
             input,

--- a/src/Metallic/kernels/rmsnorm/rmsnorm_test.rs
+++ b/src/Metallic/kernels/rmsnorm/rmsnorm_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::rmsnorm::RMSNormOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 #[test]
 fn test_rmsnorm_logic() -> Result<(), MetalError> {
@@ -8,11 +8,11 @@ fn test_rmsnorm_logic() -> Result<(), MetalError> {
 
     // Create input tensor with shape [2, 4] (2 rows, 4 features each)
     let input_data = vec![1.0, 2.0, 3.0, 4.0, -1.0, -2.0, -3.0, -4.0];
-    let input = Tensor::create_tensor_from_slice(&input_data, vec![2, 4], &ctx)?;
+    let input = Tensor::new(vec![2, 4], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
 
     // Create gamma (weight) tensor
     let gamma_data = vec![1.0, 1.0, 1.0, 1.0];
-    let gamma = Tensor::create_tensor_from_slice(&gamma_data, vec![4], &ctx)?;
+    let gamma = Tensor::new(vec![4], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&gamma_data))?;
 
     let feature_dim = 4u32;
 
@@ -70,8 +70,8 @@ fn test_rmsnorm_basic() -> Result<(), MetalError> {
     let gamma_data = vec![1.0, 1.1, 1.2, 1.3];
 
     let dims = vec![batch_size, seq_len, feature_dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let gamma_tensor = Tensor::create_tensor_from_slice(&gamma_data, vec![feature_dim], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let gamma_tensor = Tensor::new(vec![feature_dim], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&gamma_data))?;
 
     let output_tensor = context.call::<RMSNormOp>((input_tensor, gamma_tensor, feature_dim as u32))?;
     context.synchronize();
@@ -117,8 +117,8 @@ fn test_rmsnorm_numerical_stability() -> Result<(), MetalError> {
     let gamma_data = vec![1.0, 1.0, 1.0, 1.0];
 
     let dims = vec![batch_size, seq_len, feature_dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let gamma_tensor = Tensor::create_tensor_from_slice(&gamma_data, vec![feature_dim], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let gamma_tensor = Tensor::new(vec![feature_dim], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&gamma_data))?;
 
     let output_tensor = context.call::<RMSNormOp>((input_tensor, gamma_tensor, feature_dim as u32))?;
     context.synchronize();

--- a/src/Metallic/kernels/rope/mod.rs
+++ b/src/Metallic/kernels/rope/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::metallic::{Context, MetalError, Operation, Tensor, resource_cache::ResourceCache};
+use crate::metallic::{Context, MetalError, Operation, Tensor, resource_cache::ResourceCache, TensorInit, TensorStorage};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_metal::{MTLCommandBuffer, MTLComputePipelineState, MTLSize};
@@ -78,7 +78,7 @@ impl KernelInvocable for RoPEOp {
         ctx.prepare_tensors_for_active_cmd(&[&input, &cos, &sin]);
 
         // Create the output tensor with same shape as input
-        let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
+        let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         // Create the internal operation struct.
         let op = RoPE {

--- a/src/Metallic/kernels/rope/rope_test.rs
+++ b/src/Metallic/kernels/rope/rope_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::rope::RoPEOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 // CPU RoPE reference implementation for testing (pairs elements dim/2 apart)
 fn cpu_rope(input: &[f32], batch: usize, seq_len: usize, dim: usize, cos: &[f32], sin: &[f32]) -> Vec<f32> {
@@ -51,9 +51,9 @@ fn test_rope_basic() -> Result<(), MetalError> {
     }
 
     let dims = vec![batch, seq_len, dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let cos_tensor = Tensor::create_tensor_from_slice(&cos_data, vec![seq_len, dim / 2], &context)?;
-    let sin_tensor = Tensor::create_tensor_from_slice(&sin_data, vec![seq_len, dim / 2], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let cos_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&cos_data))?;
+    let sin_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&sin_data))?;
 
     let output_tensor = context.call::<RoPEOp>((input_tensor, cos_tensor, sin_tensor, dim as u32, seq_len as u32, 0))?;
     context.synchronize();
@@ -110,9 +110,9 @@ fn test_rope_extreme_large_position_values() -> Result<(), MetalError> {
     }
 
     let dims = vec![batch, seq_len, dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let cos_tensor = Tensor::create_tensor_from_slice(&cos_data, vec![seq_len, dim / 2], &context)?;
-    let sin_tensor = Tensor::create_tensor_from_slice(&sin_data, vec![seq_len, dim / 2], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let cos_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&cos_data))?;
+    let sin_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&sin_data))?;
 
     let output_tensor = context.call::<RoPEOp>((input_tensor, cos_tensor, sin_tensor, dim as u32, seq_len as u32, 0))?;
     context.synchronize();
@@ -174,9 +174,9 @@ fn test_rope_extreme_angle_values() -> Result<(), MetalError> {
     }
 
     let dims = vec![batch, seq_len, dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let cos_tensor = Tensor::create_tensor_from_slice(&cos_data, vec![seq_len, dim / 2], &context)?;
-    let sin_tensor = Tensor::create_tensor_from_slice(&sin_data, vec![seq_len, dim / 2], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let cos_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&cos_data))?;
+    let sin_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&sin_data))?;
 
     let output_tensor = context.call::<RoPEOp>((input_tensor, cos_tensor, sin_tensor, dim as u32, seq_len as u32, 0))?;
     context.synchronize();
@@ -238,9 +238,9 @@ fn test_rope_extreme_input_values() -> Result<(), MetalError> {
     }
 
     let dims = vec![batch, seq_len, dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let cos_tensor = Tensor::create_tensor_from_slice(&cos_data, vec![seq_len, dim / 2], &context)?;
-    let sin_tensor = Tensor::create_tensor_from_slice(&sin_data, vec![seq_len, dim / 2], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let cos_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&cos_data))?;
+    let sin_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&sin_data))?;
 
     let output_tensor = context.call::<RoPEOp>((input_tensor, cos_tensor, sin_tensor, dim as u32, seq_len as u32, 0))?;
     context.synchronize();
@@ -284,9 +284,9 @@ fn test_rope_extreme_cos_sin_values() -> Result<(), MetalError> {
     }
 
     let dims = vec![batch, seq_len, dim];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
-    let cos_tensor = Tensor::create_tensor_from_slice(&cos_data, vec![seq_len, dim / 2], &context)?;
-    let sin_tensor = Tensor::create_tensor_from_slice(&sin_data, vec![seq_len, dim / 2], &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
+    let cos_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&cos_data))?;
+    let sin_tensor = Tensor::new(vec![seq_len, dim / 2], TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&sin_data))?;
 
     let output_tensor = context.call::<RoPEOp>((input_tensor, cos_tensor, sin_tensor, dim as u32, seq_len as u32, 0))?;
     context.synchronize();

--- a/src/Metallic/kernels/scaled_dot_product_attention/mod.rs
+++ b/src/Metallic/kernels/scaled_dot_product_attention/mod.rs
@@ -5,9 +5,14 @@ use objc2_metal::{MTLCommandBuffer, MTLComputePipelineState};
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::kernels::matmul::mps_matrix_from_buffer;
 use crate::metallic::{
-    Context, MetalError, Operation, Tensor,
     cache_keys::{MpsMatrixDescriptorKey, MpsSoftMaxKey},
     resource_cache::ResourceCache,
+    Context,
+    MetalError,
+    Operation,
+    Tensor,
+    TensorInit,
+    TensorStorage,
 };
 
 use std::mem::size_of;
@@ -133,14 +138,14 @@ fn create_sdpa_operation(
     let scale = 1.0 / (d as f32).sqrt();
 
     // Create output tensor
-    let out = Tensor::create_tensor_pooled(vec![b, s_q, d], ctx)?;
+    let out = Tensor::new(vec![b, s_q, d], TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
     let attention = if config.reuse_workspace {
-        let buffer = Tensor::create_tensor_pooled(vec![b, s_q, s_k], ctx)?;
+        let buffer = Tensor::new(vec![b, s_q, s_k], TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         ctx.prepare_tensors_for_active_cmd(&[&buffer]);
         buffer
     } else {
-        Tensor::create_tensor_pooled(vec![b, s_q, s_k], ctx)?
+        Tensor::new(vec![b, s_q, s_k], TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?
     };
 
     ctx.prepare_tensors_for_active_cmd(&[&attention]);

--- a/src/Metallic/kernels/silu/mod.rs
+++ b/src/Metallic/kernels/silu/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::metallic::{TensorInit, TensorStorage};
 
 /// Public, user-facing, zero-sized struct for the SiLU operation.
 pub struct SiluOp;
@@ -26,7 +27,7 @@ impl KernelInvocable for SiluOp {
         let input = input;
         ctx.prepare_tensors_for_active_cmd(&[&input]);
 
-        let output = Tensor::create_tensor_pooled(input.dims().to_vec(), ctx)?;
+        let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         let op = Silu {
             input,
@@ -79,7 +80,7 @@ mod silu_test {
     fn test_silu_logic() -> Result<(), MetalError> {
         let mut ctx = Context::new()?;
         let input_data = vec![1.0, -1.0, 0.0, 2.0];
-        let input = Tensor::create_tensor_from_slice(&input_data, vec![4], &ctx)?;
+        let input = Tensor::new(vec![4], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
 
         let result = ctx.call::<SiluOp>(input)?;
 

--- a/src/Metallic/kernels/silu/silu_test.rs
+++ b/src/Metallic/kernels/silu/silu_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::metallic::kernels::silu::SiluOp;
-use crate::metallic::{Context, MetalError, Tensor};
+use crate::metallic::{Context, MetalError, Tensor, TensorInit, TensorStorage};
 
 // CPU SiLU
 fn cpu_silu(input: &[f32]) -> Vec<f32> {
@@ -20,7 +20,7 @@ fn test_silu_basic() -> Result<(), MetalError> {
 
     let input_data = vec![-2.0, -1.0, 0.0, 1.0, 2.0, -50.0, 50.0];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let output_tensor = context.call::<SiluOp>(input_tensor)?;
     context.synchronize();
@@ -53,7 +53,7 @@ fn test_silu_numerical_stability() -> Result<(), MetalError> {
         -100.0, -50.0, -20.0, -10.0, -1.0, 0.0, 1.0, 10.0, 20.0, 50.0, 100.0,
     ];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let output_tensor = context.call::<SiluOp>(input_tensor)?;
     context.synchronize();
@@ -118,7 +118,7 @@ fn test_silu_extreme_positive_values() -> Result<(), MetalError> {
     // Create input with extremely large positive values
     let input_data = vec![100.0f32, 1000.0f32, 10000.0f32, 1e6f32];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let cpu_output = cpu_silu_extreme(&input_data);
 
@@ -192,7 +192,7 @@ fn test_silu_extreme_negative_values() -> Result<(), MetalError> {
     // Create input with extremely large negative values
     let input_data = vec![-100.0f32, -1000.0f32, -10000.0f32, -1e6f32];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let cpu_output = cpu_silu_extreme(&input_data);
 
@@ -276,7 +276,7 @@ fn test_silu_mixed_extreme_values() -> Result<(), MetalError> {
     ];
     
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
     let cpu_output = cpu_silu_extreme(&input_data);
 
     let output_tensor = context.call::<SiluOp>(input_tensor)?;
@@ -345,7 +345,7 @@ fn test_silu_edge_values_around_thresholds() -> Result<(), MetalError> {
         -51.0f32, // Below negative threshold
     ];
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let cpu_output = cpu_silu_extreme(&input_data);
 
@@ -413,7 +413,7 @@ fn test_silu_large_tensor_extreme_values() -> Result<(), MetalError> {
     }
 
     let dims = vec![input_data.len()];
-    let input_tensor = Tensor::create_tensor_from_slice(&input_data, dims.clone(), &context)?;
+    let input_tensor = Tensor::new(dims.clone(), TensorStorage::Dedicated(&context), TensorInit::CopyFrom(&input_data))?;
 
     let cpu_output = cpu_silu_extreme(&input_data);
 

--- a/src/Metallic/kernels/tensors/arange.rs
+++ b/src/Metallic/kernels/tensors/arange.rs
@@ -31,7 +31,7 @@ impl KernelInvocable for ArangeOp {
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         // Create the output tensor.
-        let out = Tensor::create_tensor_pooled(vec![length], ctx)?;
+        let out = Tensor::new(vec![length], TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         // Create the internal operation struct.
         let op = Arange {
@@ -83,7 +83,7 @@ impl Operation for Arange {
 #[cfg(test)]
 mod arange_test {
     use crate::metallic::kernels::tensors::ArangeOp;
-    use crate::metallic::{Context, MetalError};
+use crate::metallic::{Context, MetalError, TensorInit, TensorStorage};
 
     #[test]
     fn test_arange() -> Result<(), MetalError> {

--- a/src/Metallic/kernels/tensors/ones.rs
+++ b/src/Metallic/kernels/tensors/ones.rs
@@ -31,7 +31,7 @@ impl KernelInvocable for OnesOp {
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         // Create the output tensor.
-        let out = Tensor::create_tensor_pooled(dims.clone(), ctx)?;
+        let out = Tensor::new(dims.clone(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         // Create the internal operation struct.
         let op = Ones {
@@ -91,7 +91,7 @@ impl Operation for Ones {
 #[cfg(test)]
 mod ones_test {
     use crate::metallic::kernels::tensors::OnesOp;
-    use crate::metallic::{Context, MetalError};
+use crate::metallic::{Context, MetalError, TensorInit, TensorStorage};
 
     #[test]
     fn test_ones() -> Result<(), MetalError> {

--- a/src/Metallic/kernels/tensors/random_uniform.rs
+++ b/src/Metallic/kernels/tensors/random_uniform.rs
@@ -36,7 +36,7 @@ impl KernelInvocable for RandomUniformOp {
         let (dims, min_val, max_val, seed_opt) = args;
 
         // Create the output tensor.
-        let out = Tensor::create_tensor_pooled(dims.clone(), ctx)?;
+        let out = Tensor::new(dims.clone(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 
         // Generate or use provided seed
         let seed = seed_opt.unwrap_or_else(|| {
@@ -109,7 +109,7 @@ impl Operation for RandomUniform {
 #[cfg(test)]
 mod random_uniform_test {
     use crate::metallic::kernels::tensors::RandomUniformOp;
-    use crate::metallic::{Context, MetalError};
+use crate::metallic::{Context, MetalError, TensorInit, TensorStorage};
 
     #[test]
     fn test_random_uniform() -> Result<(), MetalError> {

--- a/src/Metallic/pool.rs
+++ b/src/Metallic/pool.rs
@@ -86,18 +86,18 @@ impl MemoryPool {
                 self.pooled_bytes_allocated += aligned_size;
                 self.pooled_allocations += 1;
 
+                let tensor = Tensor::from_existing_buffer(
+                    self.chunks[chunk_idx].buffer.clone(),
+                    dims.clone(),
+                    dtype,
+                    &self.device,
+                    offset,
+                )?;
+
                 return Ok(PooledAllocation {
                     dtype,
                     element_size,
-                    tensor: Tensor {
-                        buf: self.chunks[chunk_idx].buffer.clone(),
-                        dims: dims.clone(),
-                        strides: Tensor::compute_strides(&dims),
-                        dtype,
-                        device: self.device.clone(),
-                        offset,
-                        defining_cmd_buffer: Rc::new(RefCell::new(None)),
-                    },
+                    tensor,
                 });
             }
         }
@@ -130,18 +130,18 @@ impl MemoryPool {
         self.pooled_bytes_allocated += aligned_size;
         self.pooled_allocations += 1;
 
+        let tensor = Tensor::from_existing_buffer(
+            self.chunks[chunk_idx].buffer.clone(),
+            dims.clone(),
+            dtype,
+            &self.device,
+            offset,
+        )?;
+
         Ok(PooledAllocation {
             dtype,
             element_size,
-            tensor: Tensor {
-                buf: self.chunks[chunk_idx].buffer.clone(),
-                dims: dims.clone(),
-                strides: Tensor::compute_strides(&dims),
-                dtype,
-                device: self.device.clone(),
-                offset,
-                defining_cmd_buffer: Rc::new(RefCell::new(None)),
-            },
+            tensor,
         })
     }
 

--- a/src/alternatives/sdpa_metal.rs
+++ b/src/alternatives/sdpa_metal.rs
@@ -1,3 +1,4 @@
+use crate::metallic::tensor::Dtype;
 use objc2::AnyThread;
 use objc2::rc::autoreleasepool;
 use objc2_metal::MTLCommandBuffer;
@@ -167,7 +168,13 @@ pub fn scaled_dot_product_attention_metal(
         }
 
         // Wrap the output buffer in our Tensor API and copy out via to_vec for consistency
-        let out_tensor = crate::metallic::Tensor::from_existing_buffer(out_buf.clone(), vec![batch, seq_q, dim], &device, 0)
+        let out_tensor = crate::metallic::Tensor::from_existing_buffer(
+            out_buf.clone(),
+            vec![batch, seq_q, dim],
+            Dtype::F32,
+            &device,
+            0,
+        )
             .expect("failed to wrap out_buf as Tensor");
         out_tensor.to_vec()
     })

--- a/src/gguf/model_loader.rs
+++ b/src/gguf/model_loader.rs
@@ -1,7 +1,7 @@
 use super::{GGUFDataType, GGUFError, GGUFFile};
 use crate::{
     gguf::GGUFValue,
-    metallic::{Context, Tensor, resource_cache::ResourceCache},
+    metallic::{Context, Tensor, TensorInit, TensorStorage, resource_cache::ResourceCache},
 };
 use half::f16;
 use std::collections::HashMap;
@@ -68,7 +68,7 @@ impl GGUFModelLoader {
                             dims = vec![151936, 896];
                             //println!("Swapped dims for token_embd.weight to [vocab, d_model]");
                         }
-                        match crate::metallic::Tensor::create_tensor_from_slice(&f32_data, dims, _context) {
+                        match crate::metallic::Tensor::new(dims, TensorStorage::Dedicated(&_context), TensorInit::CopyFrom(&f32_data)) {
                             Ok(t) => {
                                 tensors.insert(tensor_info.name.clone(), t);
                                 continue;
@@ -111,7 +111,7 @@ impl GGUFModelLoader {
                                     match deq_res {
                                         Ok(f32_data) => {
                                             let dims: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
-                                            match crate::metallic::Tensor::create_tensor_from_slice(&f32_data, dims, _context) {
+                                            match crate::metallic::Tensor::new(dims, TensorStorage::Dedicated(&_context), TensorInit::CopyFrom(&f32_data)) {
                                                 Ok(t) => {
                                                     tensors.insert(tensor_info.name.clone(), t);
                                                 }
@@ -150,7 +150,7 @@ impl GGUFModelLoader {
                                         dims = vec![151936, 896];
                                         //println!("Swapped dims for token_embd.weight to [vocab, d_model]");
                                     }
-                                    match crate::metallic::Tensor::create_tensor_from_slice(&f32_data, dims, _context) {
+                                    match crate::metallic::Tensor::new(dims, TensorStorage::Dedicated(&_context), TensorInit::CopyFrom(&f32_data)) {
                                         Ok(t) => {
                                             tensors.insert(tensor_info.name.clone(), t);
                                         }


### PR DESCRIPTION
## Summary
- introduce `TensorStorage` and `TensorInit` enums and consolidate tensor construction in a new `Tensor::new` helper
- route the memory pool, zero-initialization helpers, and all call sites through the unified API
- update loader/tests/docs to reference the new entry point and document the initialization flow

## Testing
- not run (Metal toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9c6bfe59883269860a5e0a3e262df