### PR TITLE
Use private Metal buffers with staging for tensors

### DIFF
--- a/IMPROVEMENTS_TODO.md
+++ b/IMPROVEMENTS_TODO.md
@@ -12,7 +12,7 @@ This checklist captures potential optimizations and hardening opportunities disc
 - [x] Plumb explicit synchronization for tensors returned from pooled allocations (e.g., mark when blit zeroing completes) so downstream code can skip redundant `clone()` handles. (KV cache entries track a zeroing-complete flag consumed by fast paths.)
 
 ## ⚙️ Medium-effort improvements
-- [ ] Switch pooled and ad-hoc tensors from `StorageModeShared` to `StorageModePrivate` with blit-based staging buffers to cut host RAM footprint and improve bandwidth. 【F:src/metallic/pool.rs†L98-L107】【F:src/metallic/tensor.rs†L78-L131】
+- [x] Switch pooled and ad-hoc tensors from `StorageModeShared` to `StorageModePrivate` with blit-based staging buffers to cut host RAM footprint and improve bandwidth. 【F:src/metallic/pool.rs†L98-L107】【F:src/metallic/tensor.rs†L78-L131】
 - [ ] Introduce a dedicated host staging allocator (possibly using `MTLHeap` or `MTLBuffer` recycling) to avoid allocating new shared buffers for every GGUF tensor. 【F:src/gguf/model_loader.rs†L20-L135】
 - [ ] Add lazy, demand-paged GGUF tensor loading (memory-mapped files plus per-layer uploads) instead of materializing the full model as `Vec<f32>` in RAM. 【F:src/gguf/model_loader.rs†L35-L135】
 - [ ] Expand `Tensor` to carry dtype metadata through kernels and loaders so models can stay in native precision (e.g., keep weights in `bf16/fp16` until a kernel demands `fp32`). 【F:src/metallic/tensor.rs†L19-L140】

--- a/src/alternatives/sdpa_metal.rs
+++ b/src/alternatives/sdpa_metal.rs
@@ -168,8 +168,16 @@ pub fn scaled_dot_product_attention_metal(
         }
 
         // Wrap the output buffer in our Tensor API and copy out via to_vec for consistency
-        let out_tensor = crate::metallic::Tensor::from_existing_buffer(out_buf.clone(), vec![batch, seq_q, dim], Dtype::F32, &device, 0)
-            .expect("failed to wrap out_buf as Tensor");
+        let out_tensor = crate::metallic::Tensor::from_existing_buffer(
+            out_buf.clone(),
+            vec![batch, seq_q, dim],
+            Dtype::F32,
+            &device,
+            &command_queue,
+            0,
+            true,
+        )
+        .expect("failed to wrap out_buf as Tensor");
         out_tensor.to_vec()
     })
 }

--- a/src/metallic/kernels/elemwise_add/elemwise_broadcast_add.rs
+++ b/src/metallic/kernels/elemwise_add/elemwise_broadcast_add.rs
@@ -35,7 +35,7 @@ impl KernelInvocable for BroadcastElemwiseAddOp {
             return Err(MetalError::InvalidShape(format!("Broadcast b must be 1D, got {:?}", b.dims())));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b])?;
 
         let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let op = BroadcastElemwiseAdd {

--- a/src/metallic/kernels/elemwise_add/mod.rs
+++ b/src/metallic/kernels/elemwise_add/mod.rs
@@ -43,7 +43,7 @@ impl KernelInvocable for ElemwiseAddOp {
                 b.dims(),
             )));
         }
-        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b])?;
         let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let op = ElemwiseAdd {
             a,

--- a/src/metallic/kernels/elemwise_div/mod.rs
+++ b/src/metallic/kernels/elemwise_div/mod.rs
@@ -35,7 +35,7 @@ impl KernelInvocable for ElemwiseDivOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b])?;
 
         let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/elemwise_mul/mod.rs
+++ b/src/metallic/kernels/elemwise_mul/mod.rs
@@ -35,7 +35,7 @@ impl KernelInvocable for ElemwiseMulOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b])?;
 
         let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/elemwise_sub/mod.rs
+++ b/src/metallic/kernels/elemwise_sub/mod.rs
@@ -35,7 +35,7 @@ impl KernelInvocable for ElemwiseSubOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&a, &b]);
+        ctx.prepare_tensors_for_active_cmd(&[&a, &b])?;
 
         let out = Tensor::new(a.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/gelu/mod.rs
+++ b/src/metallic/kernels/gelu/mod.rs
@@ -23,7 +23,7 @@ impl KernelInvocable for GeluOp {
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         let input = input;
-        ctx.prepare_tensors_for_active_cmd(&[&input]);
+        ctx.prepare_tensors_for_active_cmd(&[&input])?;
 
         let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/kv_rearrange/mod.rs
+++ b/src/metallic/kernels/kv_rearrange/mod.rs
@@ -38,7 +38,7 @@ impl KernelInvocable for KvRearrangeOp {
         let batch = input_m / seq as usize;
         let output_dims = vec![batch * n_heads as usize, seq as usize, head_dim as usize];
 
-        ctx.prepare_tensors_for_active_cmd(&[&input]);
+        ctx.prepare_tensors_for_active_cmd(&[&input])?;
 
         let output = Tensor::new(output_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/layernorm/mod.rs
+++ b/src/metallic/kernels/layernorm/mod.rs
@@ -52,7 +52,7 @@ impl KernelInvocable for LayerNormOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&input, &gamma, &beta]);
+        ctx.prepare_tensors_for_active_cmd(&[&input, &gamma, &beta])?;
 
         let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -55,7 +55,7 @@ impl KernelInvocable for MatMulAlphaBetaOp {
         let (right_tensor, right_view) = right.ensure_mps_contiguous_batch(ctx)?;
         let result_view = result.as_mps_matrix_batch_view()?;
 
-        ctx.prepare_tensors_for_active_cmd(&[&left_tensor, &right_tensor, result]);
+        ctx.prepare_tensors_for_active_cmd(&[&left_tensor, &right_tensor, result])?;
 
         // Calculate effective dimensions based on transpose
         let (eff_left_rows, eff_left_cols) = if transpose_left {

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -63,7 +63,7 @@ impl KernelInvocable for MatMulOp {
         let (left_tensor, left_view) = left.ensure_mps_contiguous_batch(ctx)?;
         let (right_tensor, right_view) = right.ensure_mps_contiguous_batch(ctx)?;
 
-        ctx.prepare_tensors_for_active_cmd(&[&left_tensor, &right_tensor]);
+        ctx.prepare_tensors_for_active_cmd(&[&left_tensor, &right_tensor])?;
 
         // Calculate effective dimensions based on transpose
         let (eff_left_rows, eff_left_cols) = if transpose_left {

--- a/src/metallic/kernels/permute/mod.rs
+++ b/src/metallic/kernels/permute/mod.rs
@@ -48,7 +48,7 @@ impl KernelInvocable for PermuteOp {
             out_dims[i] = src.dims()[p_idx as usize];
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&src]);
+        ctx.prepare_tensors_for_active_cmd(&[&src])?;
 
         // Create the output tensor
         let dst = Tensor::new(out_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;

--- a/src/metallic/kernels/repeat_kv_heads/mod.rs
+++ b/src/metallic/kernels/repeat_kv_heads/mod.rs
@@ -95,7 +95,7 @@ impl KernelInvocable for RepeatKvHeadsOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&input]);
+        ctx.prepare_tensors_for_active_cmd(&[&input])?;
 
         let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];
         let output = Tensor::new(output_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;

--- a/src/metallic/kernels/rmsnorm/mod.rs
+++ b/src/metallic/kernels/rmsnorm/mod.rs
@@ -42,7 +42,7 @@ impl KernelInvocable for RMSNormOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&input, &gamma]);
+        ctx.prepare_tensors_for_active_cmd(&[&input, &gamma])?;
 
         let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/rope/mod.rs
+++ b/src/metallic/kernels/rope/mod.rs
@@ -75,7 +75,7 @@ impl KernelInvocable for RoPEOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&input, &cos, &sin]);
+        ctx.prepare_tensors_for_active_cmd(&[&input, &cos, &sin])?;
 
         // Create the output tensor with same shape as input
         let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;

--- a/src/metallic/kernels/scaled_dot_product_attention/mod.rs
+++ b/src/metallic/kernels/scaled_dot_product_attention/mod.rs
@@ -94,7 +94,7 @@ fn create_sdpa_operation(
 ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
     let (q, k, v, causal, query_offset) = args;
 
-    ctx.prepare_tensors_for_active_cmd(&[q, k, v]);
+    ctx.prepare_tensors_for_active_cmd(&[q, k, v])?;
 
     // Validate dimensions
     if q.dims().len() != 3 || k.dims().len() != 3 || v.dims().len() != 3 {
@@ -138,13 +138,13 @@ fn create_sdpa_operation(
 
     let attention = if config.reuse_workspace {
         let buffer = Tensor::new(vec![b, s_q, s_k], TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
-        ctx.prepare_tensors_for_active_cmd(&[&buffer]);
+        ctx.prepare_tensors_for_active_cmd(&[&buffer])?;
         buffer
     } else {
         Tensor::new(vec![b, s_q, s_k], TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?
     };
 
-    ctx.prepare_tensors_for_active_cmd(&[&attention]);
+    ctx.prepare_tensors_for_active_cmd(&[&attention])?;
 
     let (k_operand, transpose_b) = if config.transpose_k {
         (k.clone(), true)

--- a/src/metallic/kernels/silu/mod.rs
+++ b/src/metallic/kernels/silu/mod.rs
@@ -25,7 +25,7 @@ impl KernelInvocable for SiluOp {
         _cache: std::option::Option<&mut crate::metallic::resource_cache::ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor), MetalError> {
         let input = input;
-        ctx.prepare_tensors_for_active_cmd(&[&input]);
+        ctx.prepare_tensors_for_active_cmd(&[&input])?;
 
         let output = Tensor::new(input.dims().to_vec(), TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
 

--- a/src/metallic/kernels/softmax/mod.rs
+++ b/src/metallic/kernels/softmax/mod.rs
@@ -122,7 +122,7 @@ fn try_apply_mps_softmax(
     rows: usize,
     columns: usize,
 ) -> Result<(), MetalError> {
-    ctx.prepare_tensors_for_active_cmd(&[attn]);
+    ctx.prepare_tensors_for_active_cmd(&[attn])?;
 
     let descriptor_key = MpsMatrixDescriptorKey {
         rows,
@@ -229,7 +229,7 @@ impl KernelInvocable for SoftmaxOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[attn]);
+        ctx.prepare_tensors_for_active_cmd(&[attn])?;
 
         let op = SoftmaxOperation {
             attn: attn.clone(),

--- a/src/metallic/kernels/swiglu/mod.rs
+++ b/src/metallic/kernels/swiglu/mod.rs
@@ -60,7 +60,7 @@ fn execute_swiglu_logic(
     ffn_down_bias: &Tensor,
     mut cache: Option<&mut ResourceCache>,
 ) -> Result<Tensor, MetalError> {
-    ctx.prepare_tensors_for_active_cmd(&[x_normed_flat, ffn_gate, ffn_gate_bias, ffn_up, ffn_up_bias, ffn_down, ffn_down_bias]);
+    ctx.prepare_tensors_for_active_cmd(&[x_normed_flat, ffn_gate, ffn_gate_bias, ffn_up, ffn_up_bias, ffn_down, ffn_down_bias])?;
     let d_model = x_normed_flat.dims()[1];
 
     // gate_proj: [m, d_model] @ weight -> [m, ff_dim]

--- a/src/metallic/tests/error_path_test.rs
+++ b/src/metallic/tests/error_path_test.rs
@@ -176,7 +176,9 @@ fn test_tensor_from_existing_buffer_invalid_offset() {
         vec![1, 2], // Smaller dimensions
         Dtype::F32,
         &context.device,
+        &context.command_queue,
         invalid_offset,
+        false,
     );
 
     assert!(result.is_err(), "Tensor creation should fail with invalid offset");

--- a/src/metallic/tests/forward_pass_correctness_test.rs
+++ b/src/metallic/tests/forward_pass_correctness_test.rs
@@ -175,8 +175,8 @@ fn run_blocks_up_to(model: &Qwen25, mut x: Tensor, up_to: usize, ctx: &mut Conte
                 sin_buf[idx] = angle.sin();
             }
         }
-        let cos_q = Tensor::new(vec![seq, dim_half], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&cos_buf))?;
-        let sin_q = Tensor::new(vec![seq, dim_half], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&sin_buf))?;
+        let cos_q = Tensor::new(vec![seq, dim_half], TensorStorage::Dedicated(ctx), TensorInit::CopyFrom(&cos_buf))?;
+        let sin_q = Tensor::new(vec![seq, dim_half], TensorStorage::Dedicated(ctx), TensorInit::CopyFrom(&sin_buf))?;
         let q_heads_after_rope = ctx.call::<RoPEOp>((q_heads.clone(), cos_q.clone(), sin_q.clone(), head_dim as u32, seq as u32, 0))?;
         ctx.synchronize();
 
@@ -196,12 +196,12 @@ fn run_blocks_up_to(model: &Qwen25, mut x: Tensor, up_to: usize, ctx: &mut Conte
         }
         let cos_k = Tensor::new(
             vec![seq, dim_half_k],
-            TensorStorage::Dedicated(&ctx),
+            TensorStorage::Dedicated(ctx),
             TensorInit::CopyFrom(&cos_buf_k),
         )?;
         let sin_k = Tensor::new(
             vec![seq, dim_half_k],
-            TensorStorage::Dedicated(&ctx),
+            TensorStorage::Dedicated(ctx),
             TensorInit::CopyFrom(&sin_buf_k),
         )?;
         let k_heads_after_rope = ctx.call::<RoPEOp>((k_heads, cos_k, sin_k, kv_head_dim as u32, seq as u32, 0))?;

--- a/src/metallic/tests/tensor_test.rs
+++ b/src/metallic/tests/tensor_test.rs
@@ -70,7 +70,16 @@ fn get_batch_and_from_existing_buffer() {
 
     // wrap the second batch region using from_existing_buffer
     let offset_bytes = 12 * std::mem::size_of::<f32>();
-    let view = Tensor::from_existing_buffer(base.buf.clone(), vec![3, 4], Dtype::F32, &base.device, offset_bytes).unwrap();
+    let view = Tensor::from_existing_buffer(
+        base.buf.clone(),
+        vec![3, 4],
+        Dtype::F32,
+        &base.device,
+        &ctx.command_queue,
+        offset_bytes,
+        false,
+    )
+    .unwrap();
     assert_eq!(view.as_slice(), expected.as_slice());
 }
 


### PR DESCRIPTION
## Summary
- switch pooled and dedicated tensor allocations to `StorageModePrivate` and stage host transfers through shared buffers
- track host staging state on tensors and flush pending writes before GPU work via the context
- plumb the command queue through memory pool/tensor helpers and update kernels/tests for the fallible prep path

## Testing
- Not run (Metal GPU access is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9d032886083269417ec9246c88d94