### PR TITLE
Add reusable staging allocator for GGUF tensor uploads

### DIFF
--- a/src/gguf/model_loader.rs
+++ b/src/gguf/model_loader.rs
@@ -11,7 +11,7 @@ use crate::{
 use half::f16;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLDevice, MTLResourceOptions};
+use objc2_metal::{MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLDevice, MTLResourceOptions};
 use std::collections::HashMap;
 
 fn convert_f16_bytes(raw: &[u8]) -> Result<Vec<f32>, GGUFError> {


### PR DESCRIPTION
## Summary
- add a reusable host staging allocator so GGUF tensors upload without allocating a fresh shared buffer for every copy
- route F32/F16/BF16/F64 and Q8 tensor materialization through the shared staging path with additional shape validation and conversion helpers

## Testing
- not run (Metal APIs are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9dc3b1e108326ac696f975b8acec5