### PR TITLE
Generalize tensor staging and pooled allocation metadata

### DIFF
--- a/src/gguf/model_loader.rs
+++ b/src/gguf/model_loader.rs
@@ -1,17 +1,9 @@
 use super::{GGUFDataType, GGUFError, GGUFFile};
 use crate::{
     gguf::{GGUFValue, GGUTensorInfo},
-    metallic::{
-        Context, Tensor,
-        error::MetalError,
-        operation::CommandBuffer,
-        tensor::{Dtype, RetainedBuffer},
-    },
+    metallic::{Context, Tensor, TensorInit, TensorStorage},
 };
 use half::f16;
-use objc2::rc::Retained;
-use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLDevice, MTLResourceOptions};
 use std::collections::HashMap;
 
 fn convert_f16_bytes(raw: &[u8]) -> Result<Vec<f32>, GGUFError> {
@@ -61,144 +53,16 @@ fn convert_f64_bytes(raw: &[u8]) -> Result<Vec<f32>, GGUFError> {
     Ok(f32_data)
 }
 
-const STAGING_ALIGNMENT: usize = 64 * 1024;
-
-fn align_up(value: usize, alignment: usize) -> usize {
-    if value == 0 {
-        0
-    } else {
-        value.div_ceil(alignment) * alignment
-    }
+fn tensor_from_slice(tensor_name: &str, dims: Vec<usize>, data: &[f32], context: &Context) -> Result<Tensor, GGUFError> {
+    Tensor::new(dims, TensorStorage::Dedicated(context), TensorInit::CopyFrom(data))
+        .map_err(|err| GGUFError::InvalidTensorData(format!("Failed to upload tensor '{}': {}", tensor_name, err)))
 }
 
-struct HostStagingBuffer {
-    buffer: RetainedBuffer,
-    capacity: usize,
-}
-
-struct HostStagingAllocator {
-    device: Retained<ProtocolObject<dyn MTLDevice>>,
-    free_list: Vec<HostStagingBuffer>,
-}
-
-impl HostStagingAllocator {
-    fn new(device: &Retained<ProtocolObject<dyn MTLDevice>>) -> Self {
-        Self {
-            device: device.clone(),
-            free_list: Vec::new(),
-        }
-    }
-
-    fn acquire(&mut self, required_bytes: usize) -> Result<HostStagingLease<'_>, MetalError> {
-        let buffer = if let Some(idx) = self.free_list.iter().position(|entry| entry.capacity >= required_bytes) {
-            self.free_list.swap_remove(idx)
-        } else {
-            self.allocate_buffer(required_bytes)?
-        };
-
-        Ok(HostStagingLease {
-            allocator: self,
-            buffer: Some(buffer),
-        })
-    }
-
-    fn allocate_buffer(&self, required_bytes: usize) -> Result<HostStagingBuffer, MetalError> {
-        let capacity = std::cmp::max(align_up(required_bytes, STAGING_ALIGNMENT), STAGING_ALIGNMENT);
-        let buffer = self
-            .device
-            .newBufferWithLength_options(capacity, MTLResourceOptions::StorageModeShared)
-            .ok_or(MetalError::BufferCreationFailed(capacity))?;
-
-        Ok(HostStagingBuffer { buffer, capacity })
-    }
-}
-
-struct HostStagingLease<'a> {
-    allocator: &'a mut HostStagingAllocator,
-    buffer: Option<HostStagingBuffer>,
-}
-
-impl<'a> HostStagingLease<'a> {
-    fn as_mut_slice(&mut self, len: usize) -> &mut [u8] {
-        let buf = self.buffer.as_ref().expect("staging buffer missing");
-        assert!(len <= buf.capacity, "requested slice exceeds staging capacity");
-        unsafe { std::slice::from_raw_parts_mut(buf.buffer.contents().as_ptr() as *mut u8, len) }
-    }
-
-    fn buffer(&self) -> &RetainedBuffer {
-        &self.buffer.as_ref().expect("staging buffer missing").buffer
-    }
-}
-
-impl<'a> Drop for HostStagingLease<'a> {
-    fn drop(&mut self) {
-        if let Some(buf) = self.buffer.take() {
-            self.allocator.free_list.push(buf);
-        }
-    }
-}
-
-fn metal_to_tensor_error(tensor_name: &str, stage: &str, err: MetalError) -> GGUFError {
-    GGUFError::InvalidTensorData(format!("{} for tensor '{}': {}", stage, tensor_name, err))
-}
-
-fn upload_f32_tensor_from_bytes(
-    tensor_name: &str,
-    dims: Vec<usize>,
-    bytes: &[u8],
-    context: &Context,
-    staging: &mut HostStagingAllocator,
-) -> Result<Tensor, GGUFError> {
-    let byte_len = bytes.len();
-
-    let dest_buf = context
-        .device
-        .newBufferWithLength_options(byte_len, MTLResourceOptions::StorageModePrivate)
-        .ok_or_else(|| {
-            metal_to_tensor_error(
-                tensor_name,
-                "Failed to allocate device buffer",
-                MetalError::BufferCreationFailed(byte_len),
-            )
-        })?;
-
-    if byte_len > 0 {
-        let mut lease = staging
-            .acquire(byte_len)
-            .map_err(|err| metal_to_tensor_error(tensor_name, "Failed to allocate staging buffer", err))?;
-
-        lease.as_mut_slice(byte_len).copy_from_slice(bytes);
-
-        let command_buffer = CommandBuffer::new(&context.command_queue)
-            .map_err(|err| metal_to_tensor_error(tensor_name, "Failed to create command buffer", err))?;
-
-        let encoder = command_buffer
-            .raw()
-            .blitCommandEncoder()
-            .ok_or_else(|| GGUFError::InvalidTensorData(format!("Blit encoder not available while uploading tensor '{}'", tensor_name)))?;
-
-        unsafe {
-            encoder.copyFromBuffer_sourceOffset_toBuffer_destinationOffset_size(lease.buffer(), 0, &dest_buf, 0, byte_len);
-        }
-        encoder.endEncoding();
-        command_buffer.commit();
-        command_buffer.wait();
-    }
-
-    Tensor::from_existing_buffer(dest_buf, dims, Dtype::F32, &context.device, &context.command_queue, 0, false)
-        .map_err(|err| metal_to_tensor_error(tensor_name, "Failed to finalize tensor", err))
-}
-
-fn upload_f32_tensor_from_slice(
-    tensor_name: &str,
-    dims: Vec<usize>,
-    data: &[f32],
-    context: &Context,
-    staging: &mut HostStagingAllocator,
-) -> Result<Tensor, GGUFError> {
-    let byte_len = std::mem::size_of_val(data);
-    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, byte_len) };
-    upload_f32_tensor_from_bytes(tensor_name, dims, bytes, context, staging)
+fn tensor_from_bytes(tensor_name: &str, dims: Vec<usize>, bytes: &[u8], context: &Context) -> Result<Tensor, GGUFError> {
+    debug_assert!(bytes.len().is_multiple_of(std::mem::size_of::<f32>()));
+    let elem_count = bytes.len() / std::mem::size_of::<f32>();
+    let data = unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, elem_count) };
+    tensor_from_slice(tensor_name, dims, data, context)
 }
 
 fn adjust_embedding_dims(name: &str, dims: &mut [usize]) {
@@ -227,10 +91,9 @@ impl GGUFModelLoader {
     /// Load a model from the GGUF file
     pub fn load_model(&self, context: &Context) -> Result<GGUFModel, GGUFError> {
         let mut tensors = HashMap::new();
-        let mut staging_allocator = HostStagingAllocator::new(&context.device);
 
         for tensor_info in &self.gguf_file.tensors {
-            match self.load_tensor(context, &mut staging_allocator, tensor_info) {
+            match self.load_tensor(context, tensor_info) {
                 Ok(tensor) => {
                     tensors.insert(tensor_info.name.clone(), tensor);
                 }
@@ -253,7 +116,7 @@ impl GGUFModelLoader {
         })
     }
 
-    fn load_tensor(&self, context: &Context, staging: &mut HostStagingAllocator, tensor_info: &GGUTensorInfo) -> Result<Tensor, GGUFError> {
+    fn load_tensor(&self, context: &Context, tensor_info: &GGUTensorInfo) -> Result<Tensor, GGUFError> {
         let raw = self.gguf_file.get_tensor_data(tensor_info)?;
         let mut dims: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
         adjust_embedding_dims(&tensor_info.name, &mut dims);
@@ -275,7 +138,7 @@ impl GGUFModelLoader {
                         actual,
                     });
                 }
-                upload_f32_tensor_from_bytes(&tensor_info.name, dims, raw, context, staging)
+                tensor_from_bytes(&tensor_info.name, dims, raw, context)
             }
             GGUFDataType::F16 => {
                 let f32_data = convert_f16_bytes(raw)?;
@@ -285,7 +148,7 @@ impl GGUFModelLoader {
                         actual: f32_data.len(),
                     });
                 }
-                upload_f32_tensor_from_slice(&tensor_info.name, dims, &f32_data, context, staging)
+                tensor_from_slice(&tensor_info.name, dims, &f32_data, context)
             }
             GGUFDataType::BF16 => {
                 let f32_data = convert_bf16_bytes(raw)?;
@@ -295,7 +158,7 @@ impl GGUFModelLoader {
                         actual: f32_data.len(),
                     });
                 }
-                upload_f32_tensor_from_slice(&tensor_info.name, dims, &f32_data, context, staging)
+                tensor_from_slice(&tensor_info.name, dims, &f32_data, context)
             }
             GGUFDataType::F64 => {
                 let f32_data = convert_f64_bytes(raw)?;
@@ -305,7 +168,7 @@ impl GGUFModelLoader {
                         actual: f32_data.len(),
                     });
                 }
-                upload_f32_tensor_from_slice(&tensor_info.name, dims, &f32_data, context, staging)
+                tensor_from_slice(&tensor_info.name, dims, &f32_data, context)
             }
             GGUFDataType::Q8_0 | GGUFDataType::Q8_1 => {
                 #[cfg(target_arch = "aarch64")]
@@ -321,7 +184,7 @@ impl GGUFModelLoader {
                         actual: dequant.len(),
                     });
                 }
-                upload_f32_tensor_from_slice(&tensor_info.name, dims, &dequant, context, staging)
+                tensor_from_slice(&tensor_info.name, dims, &dequant, context)
             }
             _ => Err(GGUFError::InvalidTensorData(format!(
                 "Unsupported tensor data type: {:?}",

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -417,11 +417,11 @@ impl Context {
         let repeated_k_allocation = self.kv_cache_pool.alloc_tensor::<F32Element>(repeated_dims.clone())?;
         let repeated_v_allocation = self.kv_cache_pool.alloc_tensor::<F32Element>(repeated_dims)?;
 
-        let dtype = k_allocation.dtype;
-        let element_size = k_allocation.element_size;
-        debug_assert_eq!(dtype, v_allocation.dtype);
-        debug_assert_eq!(dtype, repeated_k_allocation.dtype);
-        debug_assert_eq!(dtype, repeated_v_allocation.dtype);
+        let dtype = k_allocation.dtype();
+        let element_size = k_allocation.element_size();
+        debug_assert_eq!(dtype, v_allocation.dtype());
+        debug_assert_eq!(dtype, repeated_k_allocation.dtype());
+        debug_assert_eq!(dtype, repeated_v_allocation.dtype());
 
         let k = k_allocation.into_tensor();
         let v = v_allocation.into_tensor();

--- a/src/metallic/pool.rs
+++ b/src/metallic/pool.rs
@@ -34,11 +34,19 @@ pub struct MemoryPool {
 /// Metadata describing an allocation made from the memory pool.
 pub struct PooledAllocation<T: TensorElement> {
     pub tensor: Tensor<T>,
-    pub dtype: Dtype,
-    pub element_size: usize,
 }
 
 impl<T: TensorElement> PooledAllocation<T> {
+    #[inline]
+    pub fn dtype(&self) -> Dtype {
+        T::DTYPE
+    }
+
+    #[inline]
+    pub fn element_size(&self) -> usize {
+        T::DTYPE.size_bytes()
+    }
+
     #[inline]
     pub fn into_tensor(self) -> Tensor<T> {
         self.tensor
@@ -106,11 +114,7 @@ impl MemoryPool {
                     false,
                 )?;
 
-                return Ok(PooledAllocation {
-                    dtype,
-                    element_size,
-                    tensor,
-                });
+                return Ok(PooledAllocation { tensor });
             }
         }
 
@@ -152,11 +156,7 @@ impl MemoryPool {
             false,
         )?;
 
-        Ok(PooledAllocation {
-            dtype,
-            element_size,
-            tensor,
-        })
+        Ok(PooledAllocation { tensor })
     }
 
     /// Attempts to allocate in a specific chunk, returns offset if successful.

--- a/src/metallic/tensor.rs
+++ b/src/metallic/tensor.rs
@@ -833,10 +833,7 @@ impl Tensor<F32Element> {
     /// the first matrix in each batch may begin `matrix_bytes` bytes apart even if only a
     /// subset of the logical rows are active. Batched MPS operations require each matrix to
     /// be tightly packed, so this helper materializes a compact copy when padding is present.
-    pub fn ensure_mps_contiguous_batch(
-        &self,
-        ctx: &mut Context,
-    ) -> Result<(Self, MpsMatrixBatchView), MetalError> {
+    pub fn ensure_mps_contiguous_batch(&self, ctx: &mut Context) -> Result<(Self, MpsMatrixBatchView), MetalError> {
         let view = self.as_mps_matrix_batch_view()?;
 
         let needs_copy = view.batch > 1 && view.matrix_bytes != view.rows * view.row_bytes;


### PR DESCRIPTION
## Summary
- expose dtype and element size accessors on pooled allocations and update KV cache bookkeeping to use the typed metadata
- replace the GGUF loader staging allocator with Tensor::new-based helpers for uploading f32 slices and byte buffers

## Testing
- Not run (Metal toolchain unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9e9caaf588326aa1182a9ba8916ed