### PR TITLE
Add dtype promotion helpers for Metal kernels

### DIFF
--- a/src/gguf/model_loader.rs
+++ b/src/gguf/model_loader.rs
@@ -1,4 +1,5 @@
 use super::{GGUFDataType, GGUFError, GGUFFile, GGUFRawTensor};
+use crate::metallic::tensor::TensorInit;
 use crate::{
     gguf::{GGUFValue, GGUTensorInfo},
     metallic::{
@@ -6,7 +7,6 @@ use crate::{
         TensorF32, TensorStorage,
     },
 };
-use crate::metallic::tensor::TensorInit;
 use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
 use std::ops::Deref;

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -97,6 +97,8 @@ pub enum KernelFunction {
     Arange,
     Ones,
     RandomUniform,
+    ConvertF16ToF32,
+    ConvertBF16ToF32,
 }
 
 impl KernelFunction {
@@ -116,7 +118,11 @@ impl KernelFunction {
             KernelFunction::RMSNorm => KernelLibrary::RMSNorm,
             KernelFunction::Silu => KernelLibrary::Silu,
             KernelFunction::FusedSoftmax => KernelLibrary::Softmax,
-            KernelFunction::Arange | KernelFunction::Ones | KernelFunction::RandomUniform => KernelLibrary::Tensors,
+            KernelFunction::Arange
+            | KernelFunction::Ones
+            | KernelFunction::RandomUniform
+            | KernelFunction::ConvertF16ToF32
+            | KernelFunction::ConvertBF16ToF32 => KernelLibrary::Tensors,
         }
     }
 
@@ -140,6 +146,8 @@ impl KernelFunction {
             KernelFunction::Arange => "arange_kernel",
             KernelFunction::Ones => "ones_kernel",
             KernelFunction::RandomUniform => "random_uniform",
+            KernelFunction::ConvertF16ToF32 => "convert_f16_to_f32",
+            KernelFunction::ConvertBF16ToF32 => "convert_bf16_to_f32",
         }
     }
 }

--- a/src/metallic/kernels/scaled_dot_product_attention/mod.rs
+++ b/src/metallic/kernels/scaled_dot_product_attention/mod.rs
@@ -159,7 +159,7 @@ fn create_sdpa_operation(
 
     let softmax_result = {
         let cache_opt = cache.as_deref_mut();
-        crate::metallic::kernels::softmax::apply_softmax(
+        crate::metallic::kernels::softmax::apply_softmax::<T>(
             ctx,
             cache_opt,
             &qk_scaled_result,

--- a/src/metallic/kernels/scaled_dot_product_attention/mod.rs
+++ b/src/metallic/kernels/scaled_dot_product_attention/mod.rs
@@ -159,7 +159,7 @@ fn create_sdpa_operation(
 
     let softmax_result = {
         let cache_opt = cache.as_deref_mut();
-        crate::metallic::kernels::softmax::apply_softmax::<T>(
+        crate::metallic::kernels::softmax::apply_softmax(
             ctx,
             cache_opt,
             &qk_scaled_result,

--- a/src/metallic/kernels/softmax/mod.rs
+++ b/src/metallic/kernels/softmax/mod.rs
@@ -3,7 +3,7 @@ use crate::metallic::Dtype;
 use crate::metallic::cache_keys::{MpsMatrixDescriptorKey, MpsSoftMaxKey};
 use crate::metallic::kernels::matmul::mps_matrix_from_buffer;
 use crate::metallic::resource_cache::ResourceCache;
-use crate::metallic::tensor::{KernelElement, MpsMatrixBatchView};
+use crate::metallic::tensor::{KernelElement, MpsMatrixBatchView, Tensor as GenericTensor};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;
@@ -64,7 +64,7 @@ pub fn softmax_backend_preference() -> SoftmaxBackendPreference {
 pub fn apply_softmax<T: KernelElement>(
     ctx: &mut Context,
     mut cache: Option<&mut ResourceCache>,
-    attn: &Tensor<T>,
+    attn: &GenericTensor<T>,
     batch: usize,
     rows: usize,
     columns: usize,
@@ -73,7 +73,7 @@ pub fn apply_softmax<T: KernelElement>(
     allow_mps: bool,
 ) -> Result<Tensor, MetalError> {
     let attn_guard = attn.ensure_kernel_dtype(ctx, &[Dtype::F32])?;
-    let mut attn_tensor = attn_guard.into_tensor().into_f32()?;
+    let attn_tensor = attn_guard.into_tensor().into_f32()?;
 
     let view = attn_tensor.as_mps_matrix_batch_view()?;
 

--- a/src/metallic/kernels/tensors/kernel.metal
+++ b/src/metallic/kernels/tensors/kernel.metal
@@ -62,3 +62,27 @@ kernel void ones_kernel(
         }
     }
 }
+
+kernel void convert_f16_to_f32(
+    device const half *src [[buffer(0)]],
+    device float *dst [[buffer(1)]],
+    constant uint &total_elements [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= total_elements) {
+        return;
+    }
+    dst[gid] = float(src[gid]);
+}
+
+kernel void convert_bf16_to_f32(
+    device const bfloat *src [[buffer(0)]],
+    device float *dst [[buffer(1)]],
+    constant uint &total_elements [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= total_elements) {
+        return;
+    }
+    dst[gid] = float(src[gid]);
+}

--- a/src/metallic/mod.rs
+++ b/src/metallic/mod.rs
@@ -2,8 +2,8 @@
 pub use context::Context;
 pub use error::MetalError;
 pub use tensor::{
-    BF16Element, Dtype, F16Element, F32Element, Tensor as GenericTensor, TensorBF16, TensorElement, TensorF16, TensorF32,
-    TensorInit as GenericTensorInit, TensorStorage,
+    BF16Element, Dtype, F16Element, F32Element, KernelElement, KernelTensor, KernelTensorGuard, Tensor as GenericTensor, TensorBF16,
+    TensorElement, TensorF16, TensorF32, TensorInit as GenericTensorInit, TensorStorage,
 };
 
 pub type Tensor = TensorF32;

--- a/src/metallic/mod.rs
+++ b/src/metallic/mod.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-pub use context::Context;
+pub use context::{Context, ContextOptions};
 pub use error::MetalError;
 pub use tensor::{
     BF16Element, Dtype, F16Element, F32Element, KernelElement, KernelTensor, KernelTensorGuard, Tensor as GenericTensor, TensorBF16,

--- a/src/metallic/tensor.rs
+++ b/src/metallic/tensor.rs
@@ -1014,8 +1014,11 @@ impl KernelElement for F32Element {
             ));
         }
 
-        if supported.iter().any(|dtype| *dtype == Dtype::F32) {
-            return Ok(KernelTensorGuard::new(KernelTensor::F32(tensor.clone()), false));
+        for &target in supported {
+            match target {
+                Dtype::F32 => return Ok(KernelTensorGuard::new(KernelTensor::F32(tensor.clone()), false)),
+                _ => continue,
+            }
         }
 
         Err(MetalError::OperationNotSupported(format!(
@@ -1032,14 +1035,14 @@ impl KernelElement for F16Element {
             ));
         }
 
-        if supported.iter().any(|dtype| *dtype == Dtype::F16) {
-            return Ok(KernelTensorGuard::new(KernelTensor::F16(tensor.clone()), false));
-        }
-
         for &target in supported {
-            if target == Dtype::F32 {
-                let promoted = tensor.materialize_as_f32(ctx)?;
-                return Ok(KernelTensorGuard::new(KernelTensor::F32(promoted), true));
+            match target {
+                Dtype::F16 => return Ok(KernelTensorGuard::new(KernelTensor::F16(tensor.clone()), false)),
+                Dtype::F32 => {
+                    let promoted = tensor.materialize_as_f32(ctx)?;
+                    return Ok(KernelTensorGuard::new(KernelTensor::F32(promoted), true));
+                }
+                _ => continue,
             }
         }
 
@@ -1058,14 +1061,14 @@ impl KernelElement for BF16Element {
             ));
         }
 
-        if supported.iter().any(|dtype| *dtype == Dtype::BF16) {
-            return Ok(KernelTensorGuard::new(KernelTensor::BF16(tensor.clone()), false));
-        }
-
         for &target in supported {
-            if target == Dtype::F32 {
-                let promoted = tensor.materialize_as_f32(ctx)?;
-                return Ok(KernelTensorGuard::new(KernelTensor::F32(promoted), true));
+            match target {
+                Dtype::BF16 => return Ok(KernelTensorGuard::new(KernelTensor::BF16(tensor.clone()), false)),
+                Dtype::F32 => {
+                    let promoted = tensor.materialize_as_f32(ctx)?;
+                    return Ok(KernelTensorGuard::new(KernelTensor::F32(promoted), true));
+                }
+                _ => continue,
             }
         }
 

--- a/src/metallic/tensor.rs
+++ b/src/metallic/tensor.rs
@@ -2,7 +2,7 @@
 mod dtypes;
 
 use super::{Context, MetalError, operation::CommandBuffer};
-use crate::metallic::encoder::{dispatch_threads, set_buffer, set_bytes, set_compute_pipeline_state};
+use crate::metallic::encoder::{dispatch_threadgroups, dispatch_threads, set_buffer, set_bytes, set_compute_pipeline_state};
 use crate::metallic::kernels::KernelFunction;
 use crate::metallic::kernels::elemwise_add::ElemwiseAddOp;
 use crate::metallic::kernels::elemwise_div::ElemwiseDivOp;
@@ -936,6 +936,7 @@ impl Tensor<F16Element> {
 
         let command_buffer = ctx.active_command_buffer_mut_without_cache()?;
         let encoder = command_buffer
+            .raw()
             .computeCommandEncoder()
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 
@@ -975,6 +976,7 @@ impl Tensor<BF16Element> {
 
         let command_buffer = ctx.active_command_buffer_mut_without_cache()?;
         let encoder = command_buffer
+            .raw()
             .computeCommandEncoder()
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 

--- a/src/metallic/tests/tensor_test.rs
+++ b/src/metallic/tests/tensor_test.rs
@@ -207,6 +207,10 @@ fn f16_elementwise_promotes_to_f32() {
     let converted = a.ensure_kernel_dtype(&mut ctx, &[Dtype::F16, Dtype::F32]).unwrap();
     assert!(!converted.converted(), "should reuse native dtype when supported");
 
+    let prefer_f32 = a.ensure_kernel_dtype(&mut ctx, &[Dtype::F32, Dtype::F16]).unwrap();
+    assert!(prefer_f32.converted(), "first supported dtype should take precedence");
+    assert_eq!(prefer_f32.tensor().dtype(), Dtype::F32);
+
     let guard = a.ensure_kernel_dtype(&mut ctx, &[Dtype::F32]).unwrap();
     assert!(guard.converted(), "promotion to f32 should report conversion");
     assert_eq!(guard.tensor().dtype(), Dtype::F32);


### PR DESCRIPTION
## Summary
- add kernel dtype guards and GPU conversion kernels so f16/bf16 tensors can promote to f32 on demand
- update matmul and softmax call paths to request supported dtypes and surface the new helpers to callers
- extend tensor integration tests to cover f16/bf16 execution and verify metadata is preserved until promotion

## Testing
- not run (Metal device access is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9fbe3d22c8326b5ecee0f8ce38c0d