### PR TITLE
Align tensor size calculations with tensor element dtype

### DIFF
--- a/src/metallic/metrics.rs
+++ b/src/metallic/metrics.rs
@@ -1,8 +1,8 @@
 use crate::app_event::{LatencyRow, MemoryRow};
+use crate::metallic::TensorElement;
 use crate::metallic::instrumentation::{BlockMemorySnapshot, MemoryUsage};
 use crate::metallic::kernels::softmax::SoftmaxBackend;
 use crate::metallic::models::qwen25::Qwen25;
-use crate::metallic::TensorElement;
 use chrono::{SecondsFormat, Utc};
 use serde::Serialize;
 use serde_json::json;
@@ -674,7 +674,7 @@ pub fn build_model_memory_tree<T: TensorElement>(model: &Qwen25<T>) -> ModelMemo
         .iter()
         .enumerate()
         .map(|(idx, block)| {
-            let elem_bytes = std::mem::size_of::<f32>();
+            let elem_bytes = T::DTYPE.size_bytes();
             let d_model = model.config.d_model;
             let kv_dim = block.kv_dim;
             let q_weight_bytes = d_model * d_model * elem_bytes;

--- a/src/metallic/tensor/mod.rs
+++ b/src/metallic/tensor/mod.rs
@@ -1237,9 +1237,9 @@ impl<T: TensorElement> Tensor<T> {
         self.add_elem(&scalar_tensor, ctx)
     }
 
-    fn unary_elementwise<F>(a: &Self, f: F) -> Result<Self, MetalError> 
-    where 
-        F: Fn(f32) -> f32 
+    fn unary_elementwise<F>(a: &Self, f: F) -> Result<Self, MetalError>
+    where
+        F: Fn(f32) -> f32,
     {
         let byte_len = a.size_bytes();
         let buf = a
@@ -1277,7 +1277,7 @@ impl<T: TensorElement> Tensor<T> {
             return Err(MetalError::InvalidShape("batch_index out of bounds".to_string()));
         }
 
-        let elem_size = std::mem::size_of::<f32>();
+        let elem_size = self.dtype.size_bytes();
         let batch_stride_elems = if self.strides.len() == self.dims.len() && !self.strides.is_empty() {
             self.strides[0]
         } else {
@@ -1300,14 +1300,18 @@ impl<T: TensorElement> Tensor<T> {
             if !T::is_finite(val) {
                 return Err(MetalError::InvalidOperation(format!(
                     "Non-finite value detected at index {}: {} in tensor with shape {:?}",
-                    i, T::to_f32(val), self.dims
+                    i,
+                    T::to_f32(val),
+                    self.dims
                 )));
             }
             // Check for extremely large values that might cause overflow in subsequent operations
             if T::to_f32(T::abs(val)) > 1e6 {
                 eprintln!(
                     "Warning: Very large value detected at index {}: {} in tensor with shape {:?}. This could cause numerical instability.",
-                    i, T::to_f32(val), self.dims
+                    i,
+                    T::to_f32(val),
+                    self.dims
                 );
             }
         }


### PR DESCRIPTION
## Summary
- use the tensor element's dtype size when computing batched tensor views
- calculate model memory estimates with the active tensor element size to keep reporting accurate across dtypes

## Testing
- not run (Metal/Apple Silicon required; please run on target hardware)


------
https://chatgpt.com/codex/tasks/task_e_68db050e33208326aae0010e888861ba