### PR TITLE
Fix deterministic sampling tie-break to match reference

### DIFF
--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -44,7 +44,9 @@ pub fn sample_top_k_top_p<T: TensorElement>(logits: &[T::Scalar], top_k: usize, 
     let mut fallback_val = f32::NEG_INFINITY;
     for (i, &raw) in logits.iter().enumerate() {
         let val = T::to_f32(raw);
-        if val.is_finite() && (!fallback_found || val > fallback_val) {
+        if val.is_finite()
+            && (!fallback_found || val > fallback_val || (val == fallback_val && i > fallback_idx))
+        {
             fallback_idx = i;
             fallback_val = val;
             fallback_found = true;


### PR DESCRIPTION
## Summary
- adjust fallback selection in `sample_top_k_top_p` so greedy sampling (temperature <= 0) chooses the last-highest logit, matching the reference implementation

## Testing
- not run (Metal/Apple Silicon runtime unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dbf9d631f08326b4ff38f4caf9b64d