### PR TITLE
Vectorize SwiGLU fused activation kernel

### DIFF
--- a/src/metallic/kernels/swiglu/kernel.metal
+++ b/src/metallic/kernels/swiglu/kernel.metal
@@ -20,36 +20,31 @@ kernel void swiglu_fused_activation_##SUFFIX( \
         uint total_vector_threads = total_elements / kVectorWidth; \
         uint remainder = total_elements - total_vector_threads * kVectorWidth; \
         if (gid < total_vector_threads) { \
+            using ScalarVec = vec<SCALAR, kVectorWidth>; \
+            using AccumVec = vec<ACCUM, kVectorWidth>; \
+ \
             uint base_idx = gid * kVectorWidth; \
-            uint bias_idx = base_idx % bias_len; \
-            uint bias_vec_idx = bias_idx / kVectorWidth; \
-            device const vec<SCALAR, kVectorWidth>* gate_vec = \
-                reinterpret_cast<device const vec<SCALAR, kVectorWidth>*>(gate); \
-            device vec<SCALAR, kVectorWidth>* up_vec = \
-                reinterpret_cast<device vec<SCALAR, kVectorWidth>*>(up_inout); \
-            device const vec<SCALAR, kVectorWidth>* gate_bias_vec = \
-                reinterpret_cast<device const vec<SCALAR, kVectorWidth>*>(gate_bias); \
-            device const vec<SCALAR, kVectorWidth>* up_bias_vec = \
-                reinterpret_cast<device const vec<SCALAR, kVectorWidth>*>(up_bias); \
-            vec<SCALAR, kVectorWidth> gate_values = gate_vec[gid]; \
-            vec<SCALAR, kVectorWidth> gate_bias_values = gate_bias_vec[bias_vec_idx]; \
-            vec<SCALAR, kVectorWidth> up_values = up_vec[gid]; \
-            vec<SCALAR, kVectorWidth> up_bias_values = up_bias_vec[bias_vec_idx]; \
-            ACCUM results[kVectorWidth]; \
-            for (uint lane = 0; lane < kVectorWidth; ++lane) { \
-                ACCUM gate_val = static_cast<ACCUM>(gate_values[lane]) + \
-                    static_cast<ACCUM>(gate_bias_values[lane]); \
-                ACCUM up_val = static_cast<ACCUM>(up_values[lane]) + \
-                    static_cast<ACCUM>(up_bias_values[lane]); \
-                ACCUM sigmoid = static_cast<ACCUM>(1) / (static_cast<ACCUM>(1) + exp(-gate_val)); \
-                ACCUM activated = gate_val * sigmoid; \
-                results[lane] = activated * up_val; \
-            } \
-            vec<SCALAR, kVectorWidth> result_vec = vec<SCALAR, kVectorWidth>( \
-                static_cast<SCALAR>(results[0]), \
-                static_cast<SCALAR>(results[1]), \
-                static_cast<SCALAR>(results[2]), \
-                static_cast<SCALAR>(results[3])); \
+            uint bias_vec_len = bias_len / kVectorWidth; \
+            uint bias_vec_idx = (base_idx / kVectorWidth) % bias_vec_len; \
+ \
+            device const ScalarVec* gate_vec = \
+                reinterpret_cast<device const ScalarVec*>(gate); \
+            device ScalarVec* up_vec = \
+                reinterpret_cast<device ScalarVec*>(up_inout); \
+            device const ScalarVec* gate_bias_vec = \
+                reinterpret_cast<device const ScalarVec*>(gate_bias); \
+            device const ScalarVec* up_bias_vec = \
+                reinterpret_cast<device const ScalarVec*>(up_bias); \
+ \
+            AccumVec gate_vals = static_cast<AccumVec>(gate_vec[gid]) + \
+                static_cast<AccumVec>(gate_bias_vec[bias_vec_idx]); \
+            AccumVec up_vals = static_cast<AccumVec>(up_vec[gid]) + \
+                static_cast<AccumVec>(up_bias_vec[bias_vec_idx]); \
+ \
+            const AccumVec one(static_cast<ACCUM>(1)); \
+            AccumVec sigmoid = one / (one + exp(-gate_vals)); \
+            AccumVec activated = gate_vals * sigmoid; \
+            ScalarVec result_vec = static_cast<ScalarVec>(activated * up_vals); \
             up_vec[gid] = result_vec; \
             return; \
         } else if (gid < total_vector_threads + remainder) { \

--- a/src/metallic/kernels/swiglu/kernel.metal
+++ b/src/metallic/kernels/swiglu/kernel.metal
@@ -13,7 +13,59 @@ kernel void swiglu_fused_activation_##SUFFIX( \
     device const SCALAR* up_bias [[buffer(3)]], \
     constant uint& total_elements [[buffer(4)]], \
     constant uint& bias_len [[buffer(5)]], \
+    constant uint& vector_width [[buffer(6)]], \
     uint gid [[thread_position_in_grid]]) { \
+    const uint kVectorWidth = 4; \
+    if (vector_width == kVectorWidth) { \
+        uint total_vector_threads = total_elements / kVectorWidth; \
+        uint remainder = total_elements - total_vector_threads * kVectorWidth; \
+        if (gid < total_vector_threads) { \
+            uint base_idx = gid * kVectorWidth; \
+            uint bias_idx = base_idx % bias_len; \
+            uint bias_vec_idx = bias_idx / kVectorWidth; \
+            device const vec<SCALAR, kVectorWidth>* gate_vec = \
+                reinterpret_cast<device const vec<SCALAR, kVectorWidth>*>(gate); \
+            device vec<SCALAR, kVectorWidth>* up_vec = \
+                reinterpret_cast<device vec<SCALAR, kVectorWidth>*>(up_inout); \
+            device const vec<SCALAR, kVectorWidth>* gate_bias_vec = \
+                reinterpret_cast<device const vec<SCALAR, kVectorWidth>*>(gate_bias); \
+            device const vec<SCALAR, kVectorWidth>* up_bias_vec = \
+                reinterpret_cast<device const vec<SCALAR, kVectorWidth>*>(up_bias); \
+            vec<SCALAR, kVectorWidth> gate_values = gate_vec[gid]; \
+            vec<SCALAR, kVectorWidth> gate_bias_values = gate_bias_vec[bias_vec_idx]; \
+            vec<SCALAR, kVectorWidth> up_values = up_vec[gid]; \
+            vec<SCALAR, kVectorWidth> up_bias_values = up_bias_vec[bias_vec_idx]; \
+            ACCUM results[kVectorWidth]; \
+            for (uint lane = 0; lane < kVectorWidth; ++lane) { \
+                ACCUM gate_val = static_cast<ACCUM>(gate_values[lane]) + \
+                    static_cast<ACCUM>(gate_bias_values[lane]); \
+                ACCUM up_val = static_cast<ACCUM>(up_values[lane]) + \
+                    static_cast<ACCUM>(up_bias_values[lane]); \
+                ACCUM sigmoid = static_cast<ACCUM>(1) / (static_cast<ACCUM>(1) + exp(-gate_val)); \
+                ACCUM activated = gate_val * sigmoid; \
+                results[lane] = activated * up_val; \
+            } \
+            vec<SCALAR, kVectorWidth> result_vec = vec<SCALAR, kVectorWidth>( \
+                static_cast<SCALAR>(results[0]), \
+                static_cast<SCALAR>(results[1]), \
+                static_cast<SCALAR>(results[2]), \
+                static_cast<SCALAR>(results[3])); \
+            up_vec[gid] = result_vec; \
+            return; \
+        } else if (gid < total_vector_threads + remainder) { \
+            uint scalar_idx = total_vector_threads * kVectorWidth + (gid - total_vector_threads); \
+            uint bias_idx = scalar_idx % bias_len; \
+            ACCUM gate_val = static_cast<ACCUM>(gate[scalar_idx]) + static_cast<ACCUM>(gate_bias[bias_idx]); \
+            ACCUM up_val = static_cast<ACCUM>(up_inout[scalar_idx]) + static_cast<ACCUM>(up_bias[bias_idx]); \
+            ACCUM sigmoid = static_cast<ACCUM>(1) / (static_cast<ACCUM>(1) + exp(-gate_val)); \
+            ACCUM activated = gate_val * sigmoid; \
+            ACCUM result = activated * up_val; \
+            up_inout[scalar_idx] = static_cast<SCALAR>(result); \
+            return; \
+        } else { \
+            return; \
+        } \
+    } \
     if (gid >= total_elements) return; \
     uint bias_idx = gid % bias_len; \
     ACCUM gate_val = static_cast<ACCUM>(gate[gid]) + static_cast<ACCUM>(gate_bias[bias_idx]); \

--- a/src/metallic/kernels/swiglu/mod.rs
+++ b/src/metallic/kernels/swiglu/mod.rs
@@ -118,8 +118,11 @@ impl<T: TensorElement> Operation for SwiGLUFusedActivation<T> {
             .computeCommandEncoder()
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 
+        let vector_width = std::cmp::max(self.vector_width as usize, 1);
+        let base_threads = 256usize;
+        let threads_per_tg_width = std::cmp::max(base_threads / vector_width, 1);
         let threads_per_tg = MTLSize {
-            width: 256,
+            width: threads_per_tg_width,
             height: 1,
             depth: 1,
         };


### PR DESCRIPTION
## Summary
- vectorize the Metal SwiGLU fused activation kernel when the bias dimension supports float4/half4 access and fall back to scalar processing for any leftovers
- update the Metal encoder to select the appropriate vector width, adjust threadgroup sizing, and pass the new specialization constant
- extend the SwiGLU unit tests and benchmarks to cover both the vectorized and scalar fallback execution paths

## Testing
- Not run (Metal execution requires Apple Silicon; please run `cargo test --test swiglu_test` and `cargo bench --bench swiglu_cache_benchmark` on an Apple Silicon machine)


------
https://chatgpt.com/codex/tasks/task_e_68dc4543a06c832686cc4464ebcc3294