### PR TITLE
Pretranspose Qwen25 weights to match runtime layout

### DIFF
--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -225,10 +225,10 @@ pub fn mps_matrix_from_buffer(
     let rows = unsafe { descriptor.rows() };
     let row_bytes = unsafe { descriptor.rowBytes() };
     let matrices = unsafe { descriptor.matrices() };
+    let matrix_bytes = unsafe { descriptor.matrixBytes() };
     let total_bytes = if matrices <= 1 {
-        row_bytes * rows
+        matrix_bytes
     } else {
-        let matrix_bytes = unsafe { descriptor.matrixBytes() };
         (matrices - 1) * matrix_bytes + rows * row_bytes
     };
     let size = total_bytes;

--- a/src/metallic/models/qwen25/transformer_block.rs
+++ b/src/metallic/models/qwen25/transformer_block.rs
@@ -42,10 +42,10 @@ where
         // Allocate FFN weights in the layout expected by `swiglu`:
         // - gate/up: [d_model, ff_dim]
         // - down:    [ff_dim, d_model]
-        let ffn_down = Tensor::zeros(vec![cfg.d_model, cfg.ff_dim], ctx, false)?;
-        let ffn_gate_up_weight = Tensor::zeros(vec![2 * cfg.ff_dim, cfg.d_model], ctx, false)?;
-        let ffn_gate = ffn_gate_up_weight.slice(&[0..cfg.ff_dim])?;
-        let ffn_up = ffn_gate_up_weight.slice(&[cfg.ff_dim..2 * cfg.ff_dim])?;
+        let ffn_down = Tensor::zeros(vec![cfg.ff_dim, cfg.d_model], ctx, false)?;
+        let ffn_gate_up_weight = Tensor::zeros(vec![cfg.d_model, 2 * cfg.ff_dim], ctx, false)?;
+        let ffn_gate = ffn_gate_up_weight.slice_last_dim(0..cfg.ff_dim)?;
+        let ffn_up = ffn_gate_up_weight.slice_last_dim(cfg.ff_dim..2 * cfg.ff_dim)?;
 
         // FFN biases
         let ffn_gate_bias = Tensor::zeros(vec![cfg.ff_dim], ctx, false)?;


### PR DESCRIPTION
## Summary
- store Qwen25 projection weights in the runtime [in_features, out_features] layout so matmul calls no longer request transposes
- normalize GGUF loading by transposing linear weights on ingest and reusing helpers for fused gate/up matrices

## Testing
- not run (Metal execution requires Apple Silicon hardware)

------
https://chatgpt.com/codex/tasks/task_e_68dc685909dc8326a4275c3998e13c42