### PR TITLE
Gate Metal resource cache clears on KV cache shape changes

### DIFF
--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -1026,7 +1026,6 @@ impl<T: TensorElement> Context<T> {
 
         if should_refresh {
             self.active_cmd_buffer = None;
-            self.active_resource_cache = None;
         }
 
         if self.active_cmd_buffer.is_none() {

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -48,6 +48,8 @@ pub struct Context<T: TensorElement> {
     memory_collector: Option<MemoryCollectorHandle>,
     /// Softmax backend samples collected since the last drain.
     softmax_samples: Vec<SoftmaxSample>,
+    /// Tracks the last backend that executed so instrumentation can explain cache stats.
+    last_softmax_backend: Option<SoftmaxBackend>,
     //config: ContextConfig,
 }
 
@@ -107,6 +109,7 @@ impl<T: TensorElement> Context<T> {
             latency_collector: None,
             memory_collector: None,
             softmax_samples: Vec::new(),
+            last_softmax_backend: None,
             //config,
         })
     }
@@ -168,11 +171,16 @@ impl<T: TensorElement> Context<T> {
         if duration.is_zero() {
             return;
         }
+        self.last_softmax_backend = Some(backend);
         self.softmax_samples.push(SoftmaxSample { backend, duration });
     }
 
     pub fn take_softmax_samples(&mut self) -> Vec<SoftmaxSample> {
         mem::take(&mut self.softmax_samples)
+    }
+
+    pub fn last_softmax_backend(&self) -> Option<SoftmaxBackend> {
+        self.last_softmax_backend
     }
 
     /// Registers a memory collector handle for the upcoming operations. Passing `None`

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -279,10 +279,6 @@ pub fn generate_autoregressive_with_kv_cache_streaming<F, T: TensorElement>(
 where
     F: FnMut(u32, Arc<str>) -> Result<bool, MetalError>,
 {
-    // Ensure KV caches start from a clean slate between generations.
-    ctx.kv_caches.clear();
-    ctx.kv_cache_pool.reset();
-
     // Pre-allocate KV cache for all layers
     let n_layers = qwen.config.n_layers;
     let seq_len = qwen.config.seq_len;
@@ -293,6 +289,39 @@ where
     let kv_head_dim = kv_dim / n_kv_heads;
     let batch_size = 1; // Assuming batch size of 1 for now
     let kv_capacity = (input_ids.len().max(1) + cfg.max_tokens).min(seq_len);
+
+    // Determine whether existing cache-backed descriptors must be invalidated because
+    // their shapes changed (e.g. when generating with a longer context than before).
+    let canonical_batch_heads = batch_size * n_kv_heads;
+    let repeated_batch_heads = batch_size * n_heads;
+    let mut cache_shapes_changed = false;
+    if !ctx.kv_caches.is_empty() {
+        for layer_idx in 0..n_layers {
+            match ctx.kv_caches.get(&layer_idx) {
+                Some(entry) => {
+                    let k_dims = entry.k.dims();
+                    let repeated_k_dims = entry.repeated_k.dims();
+                    if entry.capacity != kv_capacity
+                        || k_dims[0] != canonical_batch_heads
+                        || k_dims[2] != kv_head_dim
+                        || repeated_k_dims[0] != repeated_batch_heads
+                        || repeated_k_dims[2] != kv_head_dim
+                    {
+                        cache_shapes_changed = true;
+                        break;
+                    }
+                }
+                None => {
+                    cache_shapes_changed = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Ensure KV caches start from a clean slate between generations.
+    ctx.kv_caches.clear();
+    ctx.kv_cache_pool.reset();
 
     let log_interval = log_interval_from_env();
     let mut metrics_loggers = MetricsLoggers::from_env(log_interval);
@@ -317,6 +346,10 @@ where
         ctx.alloc_kv_cache(layer_idx, kv_capacity, batch_size * n_kv_heads, batch_size * n_heads, kv_head_dim)?;
     }
 
+    if cache_shapes_changed {
+        ctx.clear_cache();
+    }
+
     let mut latest_forward_usage = Some(ctx.snapshot_memory_usage());
     sample_process_memory(process_memory_tracker, host_memory);
 
@@ -324,7 +357,6 @@ where
     // Process the prompt token by token to warm up the KV cache.
     let mut logits_tensor: Option<Tensor<T>> = None;
     if !input_ids.is_empty() {
-        ctx.clear_cache(); // It's okay to clear the resource cache
         for (i, &token_id) in input_ids.iter().enumerate() {
             let input_tensor = qwen.embed(&[token_id], ctx)?;
             let hidden_states = qwen.forward_step(&input_tensor, i, ctx)?;
@@ -393,7 +425,6 @@ where
     );
     for i in 0..cfg.max_tokens - 1 {
         ctx.reset_pool();
-        ctx.clear_cache();
 
         let embed_usage_before = ctx.snapshot_memory_usage();
         let embed_start = Instant::now();


### PR DESCRIPTION
## Summary
- detect KV cache shape changes before reinitializing KV buffers during generation
- clear the Metal resource cache only when KV cache geometry changes and stop flushing it every step

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68dc9d1750a08326acaecd832d95b57e