### PR TITLE
Avoid redundant vocab logits allocation

### DIFF
--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -479,11 +479,11 @@ where
     if let Some(logits_tensor) = logits_tensor {
         // Extract logits for the very last token of the prompt
         let logits = logits_tensor.to_vec();
-        let vocab_logits = logits[0..vocab_size].to_vec();
+        let vocab_logits = &logits[..vocab_size];
 
         // Sample the first token
         let sample_start = Instant::now();
-        next_token = sample_top_k_top_p::<T>(&vocab_logits, cfg.top_k, cfg.top_p, cfg.temperature) as u32;
+        next_token = sample_top_k_top_p::<T>(vocab_logits, cfg.top_k, cfg.top_p, cfg.temperature) as u32;
         let sample_duration = sample_start.elapsed();
         if !sample_duration.is_zero() {
             sample_stats.record(sample_duration);
@@ -619,10 +619,10 @@ where
         sample_process_memory(process_memory_tracker, host_memory);
 
         let logits = logits_tensor.to_vec();
-        let vocab_logits = logits[0..vocab_size].to_vec();
+        let vocab_logits = &logits[..vocab_size];
 
         let sample_start = Instant::now();
-        next_token = sample_top_k_top_p::<T>(&vocab_logits, cfg.top_k, cfg.top_p, cfg.temperature) as u32;
+        next_token = sample_top_k_top_p::<T>(vocab_logits, cfg.top_k, cfg.top_p, cfg.temperature) as u32;
 
         generated_ids.push(next_token);
 

--- a/src/metallic/tests/generation_test.rs
+++ b/src/metallic/tests/generation_test.rs
@@ -115,10 +115,10 @@ fn test_full_generation_correctness() -> Result<(), crate::metallic::MetalError>
             let seq_len = generated.len();
             let start_idx = (seq_len - 1) * vocab_size;
             let end_idx = start_idx + vocab_size;
-            let vocab_logits = &logits[start_idx..end_idx];
+            let vocab_slice = &logits[start_idx..end_idx];
 
             // Greedy sampling (argmax)
-            let next_token = vocab_logits
+            let next_token = vocab_slice
                 .iter()
                 .enumerate()
                 .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
@@ -129,7 +129,7 @@ fn test_full_generation_correctness() -> Result<(), crate::metallic::MetalError>
                 "[Ref] Step {}: token={}, logits={:?}",
                 generated.len() - input_ids.len(),
                 next_token,
-                &vocab_logits[..10]
+                &vocab_slice[..10]
             );
 
             generated.push(next_token);


### PR DESCRIPTION
## Summary
- sample from slices backed by the logits vector during prompt warm-up and autoregressive generation to avoid unnecessary allocations
- adjust the generation unit test helper to use the borrowed slice naming that reflects the new structure

## Testing
- not run (Apple Metal runtime unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dcad72b22883268b6a6fac3e4bc5d8