### PR TITLE
Add inline hints to Metal encoder helpers

### DIFF
--- a/src/metallic/encoder.rs
+++ b/src/metallic/encoder.rs
@@ -3,6 +3,7 @@ use objc2_metal::{MTLBuffer, MTLComputeCommandEncoder, MTLComputePipelineState, 
 use std::ffi::c_void;
 
 /// Sets the compute pipeline state for a command encoder.
+#[inline]
 pub fn set_compute_pipeline_state(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     state: &ProtocolObject<dyn MTLComputePipelineState>,
@@ -11,6 +12,7 @@ pub fn set_compute_pipeline_state(
 }
 
 /// Sets a buffer for a compute kernel.
+#[inline]
 pub fn set_buffer(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     index: usize,
@@ -21,6 +23,7 @@ pub fn set_buffer(
 }
 
 /// Sets a small amount of data for a compute kernel.
+#[inline]
 pub fn set_bytes<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, index: usize, data: &T) {
     let size = std::mem::size_of::<T>();
     // SAFETY: `data` is a valid reference, so its pointer is non-null.
@@ -32,6 +35,7 @@ pub fn set_bytes<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder
 }
 
 /// Dispatches a compute kernel.
+#[inline]
 pub fn dispatch_threadgroups(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, groups: MTLSize, threads_per_tg: MTLSize) {
     debug_assert!(groups.width > 0, "groups.width must be non-zero");
     debug_assert!(groups.height > 0, "groups.height must be non-zero");
@@ -44,6 +48,7 @@ pub fn dispatch_threadgroups(encoder: &ProtocolObject<dyn MTLComputeCommandEncod
 }
 
 /// Dispatches a compute kernel using thread-level parallelism.
+#[inline]
 pub fn dispatch_threads(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, grid_size: MTLSize, threadgroup_size: MTLSize) {
     encoder.dispatchThreads_threadsPerThreadgroup(grid_size, threadgroup_size);
 }


### PR DESCRIPTION
## Summary
- add inline attributes to the Metal compute encoder helper functions to encourage inlining

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68dd44d2b3608326a03f125153f9aa31