### PR TITLE
Allow KV rearrange to consume strided QKV slices

### DIFF
--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -299,9 +299,9 @@ impl<T: TensorElement> Context<T> {
         let k_range_end = d_model + kv_dim;
         let v_range_end = expected_total;
 
-        let q_out = self.materialize_contiguous_view(linear.slice_last_dim(0..q_range_end)?)?;
-        let k_out = self.materialize_contiguous_view(linear.slice_last_dim(d_model..k_range_end)?)?;
-        let v_out = self.materialize_contiguous_view(linear.slice_last_dim(k_range_end..v_range_end)?)?;
+        let q_out = linear.slice_last_dim(0..q_range_end)?;
+        let k_out = linear.slice_last_dim(d_model..k_range_end)?;
+        let v_out = linear.slice_last_dim(k_range_end..v_range_end)?;
 
         Ok((q_out, k_out, v_out))
     }

--- a/src/metallic/kernels/kv_rearrange/kernel.metal
+++ b/src/metallic/kernels/kv_rearrange/kernel.metal
@@ -10,12 +10,13 @@ kernel void kv_rearrange_kernel_##SUFFIX( \
     device const SCALAR* input [[buffer(0)]], \
     device SCALAR* output [[buffer(1)]], \
     constant uint& kv_dim [[buffer(2)]], \
-    constant uint& kv_head_dim [[buffer(3)]], \
-    constant uint& n_heads [[buffer(4)]], \
-    constant uint& n_kv_heads [[buffer(5)]], \
-    constant uint& head_dim [[buffer(6)]], \
-    constant uint& seq [[buffer(7)]], \
-    constant uint& total_elements [[buffer(8)]], \
+    constant uint& row_stride [[buffer(3)]], \
+    constant uint& kv_head_dim [[buffer(4)]], \
+    constant uint& n_heads [[buffer(5)]], \
+    constant uint& n_kv_heads [[buffer(6)]], \
+    constant uint& head_dim [[buffer(7)]], \
+    constant uint& seq [[buffer(8)]], \
+    constant uint& total_elements [[buffer(9)]], \
     uint gid [[thread_position_in_grid]]) { \
     if (gid >= total_elements) { \
         return; \
@@ -28,8 +29,12 @@ kernel void kv_rearrange_kernel_##SUFFIX( \
     uint h = out_batch % n_heads; \
     uint group_size = n_heads / n_kv_heads; \
     uint kv_h = h / group_size; \
+    uint base_offset = kv_h * kv_head_dim + hd; \
+    if (base_offset >= kv_dim) { \
+        return; \
+    } \
     uint src_row = b * seq + s; \
-    uint src_idx = src_row * kv_dim + kv_h * kv_head_dim + hd; \
+    uint src_idx = src_row * row_stride + base_offset; \
     output[gid] = input[src_idx]; \
 }
 

--- a/src/metallic/kernels/kv_rearrange/mod.rs
+++ b/src/metallic/kernels/kv_rearrange/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::metallic::{TensorElement, TensorInit, TensorStorage};
+use std::convert::TryFrom;
 
 /// Public, user-facing, zero-sized struct for the KV rearrange operation.
 pub struct KvRearrangeOp;
@@ -9,6 +10,7 @@ struct KvRearrange<T: TensorElement> {
     input: Tensor<T>,  // [M, kv_dim]
     output: Tensor<T>, // [batch*n_heads, seq, head_dim]
     kv_dim: u32,
+    row_stride: u32,
     kv_head_dim: u32,
     n_heads: u32,
     n_kv_heads: u32,
@@ -32,6 +34,19 @@ impl KernelInvocable for KvRearrangeOp {
     ) -> Result<(Box<dyn Operation>, Tensor<T>), MetalError> {
         let (input, kv_dim, kv_head_dim, n_heads, n_kv_heads, head_dim, seq) = args;
 
+        if input.dims().len() < 2 {
+            return Err(MetalError::InvalidShape("KV rearrange expects at least 2D input".to_string()));
+        }
+
+        let row_stride_elems = input.strides.get(0).copied().unwrap_or_else(|| input.dims()[1]);
+        if row_stride_elems == 0 {
+            return Err(MetalError::InvalidShape(
+                "Row stride for KV rearrange must be greater than zero".to_string(),
+            ));
+        }
+        let row_stride =
+            u32::try_from(row_stride_elems).map_err(|_| MetalError::InvalidShape("Row stride for KV rearrange exceeds u32".to_string()))?;
+
         // Calculate output dimensions: [batch*n_heads, seq, head_dim]
         // We need to infer batch from the input dimensions: M = batch*seq
         let input_m = input.dims()[0];
@@ -46,6 +61,7 @@ impl KernelInvocable for KvRearrangeOp {
             input,
             output: output.clone(),
             kv_dim,
+            row_stride,
             kv_head_dim,
             n_heads,
             n_kv_heads,
@@ -84,12 +100,13 @@ impl<T: TensorElement> Operation for KvRearrange<T> {
         set_buffer(&encoder, 0, &self.input.buf, self.input.offset);
         set_buffer(&encoder, 1, &self.output.buf, self.output.offset);
         set_bytes(&encoder, 2, &self.kv_dim);
-        set_bytes(&encoder, 3, &self.kv_head_dim);
-        set_bytes(&encoder, 4, &self.n_heads);
-        set_bytes(&encoder, 5, &self.n_kv_heads);
-        set_bytes(&encoder, 6, &self.head_dim);
-        set_bytes(&encoder, 7, &self.seq);
-        set_bytes(&encoder, 8, &total_elements);
+        set_bytes(&encoder, 3, &self.row_stride);
+        set_bytes(&encoder, 4, &self.kv_head_dim);
+        set_bytes(&encoder, 5, &self.n_heads);
+        set_bytes(&encoder, 6, &self.n_kv_heads);
+        set_bytes(&encoder, 7, &self.head_dim);
+        set_bytes(&encoder, 8, &self.seq);
+        set_bytes(&encoder, 9, &total_elements);
 
         dispatch_threadgroups(&encoder, groups, threads_per_tg);
         encoder.endEncoding();
@@ -106,15 +123,125 @@ mod kv_rearrange_test {
     #[test]
     fn test_kv_rearrange_logic() -> Result<(), MetalError> {
         let mut ctx = Context::<F32Element>::new()?;
-        // Create a simple test tensor [batch*seq, kv_dim] = [2*3, 4] = [6, 4]
-        let input_data: Vec<f32> = (0..24).map(|i| i as f32).collect();
-        let input = Tensor::new(vec![6, 4], TensorStorage::Dedicated(&ctx), TensorInit::CopyFrom(&input_data))?;
+        let batch = 2usize;
+        let seq = 3usize;
+        let n_heads = 4usize;
+        let n_kv_heads = 2usize;
+        let head_dim = 2usize;
+        let kv_head_dim = 3usize;
+        let d_model = n_heads * head_dim;
+        let kv_dim = n_kv_heads * kv_head_dim;
+        let fused_dim = d_model + 2 * kv_dim;
+        let rows = batch * seq;
 
-        // Test parameters: kv_dim=4, kv_head_dim=2, n_heads=2, n_kv_heads=1, head_dim=2, seq=3
-        let result = ctx.call::<KvRearrangeOp>((input, 4, 2, 2, 1, 2, 3))?;
+        // Create a fused QKV tensor so slicing produces strided views.
+        let fused_data: Vec<f32> = (0..rows * fused_dim).map(|i| i as f32).collect();
+        let fused = Tensor::new(
+            vec![rows, fused_dim],
+            TensorStorage::Dedicated(&ctx),
+            TensorInit::CopyFrom(&fused_data),
+        )?;
 
-        // Verify dimensions: [batch*n_heads, seq, head_dim] = [2*2, 3, 2] = [4, 3, 2]
-        assert_eq!(result.dims(), &[4, 3, 2]);
+        let q_mat = fused.slice_last_dim(0..d_model)?;
+        let k_mat = fused.slice_last_dim(d_model..d_model + kv_dim)?;
+        let v_mat = fused.slice_last_dim(d_model + kv_dim..fused_dim)?;
+
+        let q_result = ctx.call::<KvRearrangeOp>((
+            q_mat.clone(),
+            d_model as u32,
+            head_dim as u32,
+            n_heads as u32,
+            n_heads as u32,
+            head_dim as u32,
+            seq as u32,
+        ))?;
+        let k_result = ctx.call::<KvRearrangeOp>((
+            k_mat.clone(),
+            kv_dim as u32,
+            kv_head_dim as u32,
+            n_kv_heads as u32,
+            n_kv_heads as u32,
+            kv_head_dim as u32,
+            seq as u32,
+        ))?;
+        let v_result = ctx.call::<KvRearrangeOp>((
+            v_mat.clone(),
+            kv_dim as u32,
+            kv_head_dim as u32,
+            n_kv_heads as u32,
+            n_kv_heads as u32,
+            kv_head_dim as u32,
+            seq as u32,
+        ))?;
+
+        ctx.synchronize();
+
+        // Verify output dimensions for each projection.
+        assert_eq!(q_result.dims(), &[batch * n_heads, seq, head_dim]);
+        assert_eq!(k_result.dims(), &[batch * n_kv_heads, seq, kv_head_dim]);
+        assert_eq!(v_result.dims(), &[batch * n_kv_heads, seq, kv_head_dim]);
+
+        // CPU reference for verification using the original fused buffer.
+        let row_stride = fused_dim;
+        let q_expected = cpu_reference_rearrange(&fused_data, row_stride, batch, seq, n_heads, n_heads, head_dim, head_dim, 0);
+        let k_expected = cpu_reference_rearrange(
+            &fused_data,
+            row_stride,
+            batch,
+            seq,
+            n_kv_heads,
+            n_kv_heads,
+            kv_head_dim,
+            kv_head_dim,
+            d_model,
+        );
+        let v_expected = cpu_reference_rearrange(
+            &fused_data,
+            row_stride,
+            batch,
+            seq,
+            n_kv_heads,
+            n_kv_heads,
+            kv_head_dim,
+            kv_head_dim,
+            d_model + kv_dim,
+        );
+
+        assert_eq!(q_result.as_slice(), q_expected.as_slice());
+        assert_eq!(k_result.as_slice(), k_expected.as_slice());
+        assert_eq!(v_result.as_slice(), v_expected.as_slice());
+
         Ok(())
     }
+}
+
+#[cfg(test)]
+fn cpu_reference_rearrange(
+    fused: &[f32],
+    row_stride: usize,
+    batch: usize,
+    seq: usize,
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    kv_head_dim: usize,
+    column_offset: usize,
+) -> Vec<f32> {
+    let mut output = vec![0.0f32; batch * n_heads * seq * head_dim];
+    let group_size = n_heads / n_kv_heads;
+    for b in 0..batch {
+        for h in 0..n_heads {
+            let kv_h = h / group_size;
+            for s in 0..seq {
+                let src_row = b * seq + s;
+                for d in 0..head_dim {
+                    let base_offset = kv_h * kv_head_dim + d;
+                    let src_index = src_row * row_stride + column_offset + base_offset;
+                    let dst_index = ((b * n_heads + h) * seq + s) * head_dim + d;
+                    output[dst_index] = fused[src_index];
+                }
+            }
+        }
+    }
+    output
 }

--- a/src/metallic/tests/forward_pass_correctness_test.rs
+++ b/src/metallic/tests/forward_pass_correctness_test.rs
@@ -406,7 +406,8 @@ fn test_forward_pass_correctness() -> Result<(), crate::metallic::MetalError> {
     let (q_mat, k_mat, v_mat) =
         ctx.fused_qkv_projection(&x_flat, &block0.attn_qkv_weight, &block0.attn_qkv_bias, d_model, block0.kv_dim)?;
     ctx.synchronize();
-    let rust_q_proj_slice = q_mat.as_slice();
+    let q_mat_host = ctx.materialize_contiguous_view(q_mat.clone())?;
+    let rust_q_proj_slice = q_mat_host.as_slice();
     println!(
         "Rust first Q proj first 10: {:?}",
         take_first_as_f32::<TestElement>(rust_q_proj_slice, 10)
@@ -475,7 +476,8 @@ fn test_forward_pass_correctness() -> Result<(), crate::metallic::MetalError> {
     // --- 4. Test First Block K Projection ---
     println!("--- 4. Testing First Block K Projection ---");
     let k_mat = k_mat.clone();
-    let rust_k_proj_slice = k_mat.as_slice();
+    let k_mat_host = ctx.materialize_contiguous_view(k_mat.clone())?;
+    let rust_k_proj_slice = k_mat_host.as_slice();
     println!(
         "Rust first K proj first 10: {:?}",
         take_first_as_f32::<TestElement>(rust_k_proj_slice, 10)
@@ -544,7 +546,8 @@ fn test_forward_pass_correctness() -> Result<(), crate::metallic::MetalError> {
     // --- 5. Test First Block V Projection ---
     println!("--- 5. Testing First Block V Projection ---");
     let v_mat = v_mat.clone();
-    let rust_v_proj_slice = v_mat.as_slice();
+    let v_mat_host = ctx.materialize_contiguous_view(v_mat.clone())?;
+    let rust_v_proj_slice = v_mat_host.as_slice();
     println!(
         "Rust first V proj first 10: {:?}",
         take_first_as_f32::<TestElement>(rust_v_proj_slice, 10)


### PR DESCRIPTION
## Summary
- add an explicit row stride to the Metal KV rearrange kernel and host bindings so strided inputs are read without extra copies
- return the strided Q, K, and V slices directly from `fused_qkv_projection`
- update kernel tests and forward pass checks to cover strided views while materializing only when host access is required

## Testing
- not run (Metal backend is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd574b1d3083269b429ac6ee51326a