### PR TITLE
Integrate MLX GEMM backend telemetry

### DIFF
--- a/INSTRUMENTATION.md
+++ b/INSTRUMENTATION.md
@@ -76,6 +76,23 @@ The benchmark reports separate `kernel` and `mps` measurements using identical
 tensor shapes so you can determine which backend is faster on a given piece of
 hardware.
 
+### MatMul backend benchmarking
+
+Matrix multiplication now exposes a similar instrumentation surface so the new
+MLX GEMM kernel can be compared directly against the legacy MPS path. Set the
+`METALLIC_GEMM_BACKEND` environment variable to `mps`, `cpu`, or `0` to force the
+fallback implementation when collecting baselines. With the default value the
+inference stack selects the MLX kernel whenever it supports the current tensor
+layout and dtype.
+
+Every matmul dispatch records its backend and scheduling latency. The metrics
+layer aggregates the samples into two new latency rows, **MatMul (MLX)** and
+**MatMul (MPS)**, which appear alongside the existing forward-step timings in
+the Ratatui dashboard and JSONL logs. Use the rows to validate that the MLX
+kernel outperforms the fallback for your sequence shapes, or to confirm the
+fallback remains active when the MLX kernel is disabled through the
+environment flag.
+
 ## Memory tracking
 
 The memory collector captures pool usage, KV cache growth, and per-phase deltas.

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -204,9 +204,7 @@ impl<T: TensorElement> Context<T> {
 
     pub(crate) fn record_matmul_backend_sample(&mut self, duration: Duration) {
         if let Some(backend) = self.last_matmul_backend.take() {
-            if !duration.is_zero() {
-                self.matmul_samples.push(MatMulSample { backend, duration });
-            }
+            self.matmul_samples.push(MatMulSample { backend, duration });
         }
     }
 

--- a/src/metallic/encoder.rs
+++ b/src/metallic/encoder.rs
@@ -34,6 +34,23 @@ pub fn set_bytes<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder
     }
 }
 
+/// Sets a slice of data for a compute kernel.
+#[inline]
+pub fn set_bytes_slice<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, index: usize, data: &[T]) {
+    let size = std::mem::size_of::<T>() * data.len();
+
+    unsafe {
+        if size == 0 {
+            let ptr = std::ptr::NonNull::dangling().cast::<c_void>();
+            encoder.setBytes_length_atIndex(ptr, 0, index);
+            return;
+        }
+
+        let ptr = std::ptr::NonNull::from(&data[0]).cast::<c_void>();
+        encoder.setBytes_length_atIndex(ptr, size, index);
+    }
+}
+
 /// Dispatches a compute kernel.
 #[inline]
 pub fn dispatch_threadgroups(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, groups: MTLSize, threads_per_tg: MTLSize) {

--- a/src/metallic/encoder.rs
+++ b/src/metallic/encoder.rs
@@ -41,7 +41,7 @@ pub fn set_bytes_slice<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandE
 
     unsafe {
         if size == 0 {
-            let ptr = std::ptr::NonNull::dangling().cast::<c_void>();
+            let ptr = std::ptr::NonNull::<T>::dangling().cast::<c_void>();
             encoder.setBytes_length_atIndex(ptr, 0, index);
             return;
         }

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -2,8 +2,9 @@ use super::{Context, MetalError, SamplerBuffers, Tensor};
 use crate::metallic::instrumentation::{MemoryEvent, MemoryUsage, new_latency_collector, new_memory_collector};
 use crate::metallic::kernels::softmax::SoftmaxBackend;
 use crate::metallic::metrics::{
-    BlockStat, MemoryBlockStat, MemoryScopeStat, MetricsLoggers, ModelMemoryNode, ProcessMemoryTracker, RollingStat, ScalarStat,
-    SoftmaxBackendStats, build_latency_rows, build_memory_rows, build_model_memory_tree, log_interval_from_env, sample_process_memory,
+    BlockStat, MatMulBackendStats, MemoryBlockStat, MemoryScopeStat, MetricsLoggers, ModelMemoryNode, ProcessMemoryTracker, RollingStat,
+    ScalarStat, SoftmaxBackendStats, build_latency_rows, build_memory_rows, build_model_memory_tree, log_interval_from_env,
+    sample_process_memory,
 };
 use crate::metallic::models::qwen25::Qwen25;
 use crate::metallic::{TensorElement, Tokenizer};
@@ -461,6 +462,7 @@ where
     let mut decode_stats = RollingStat::default();
     let mut block_stats = vec![BlockStat::default(); n_layers];
     let mut softmax_backend_stats = SoftmaxBackendStats::default();
+    let mut matmul_backend_stats = MatMulBackendStats::default();
     let mut latencies_ready = false;
     let mut memory_embed = MemoryScopeStat::default();
     let mut memory_forward = MemoryScopeStat::default();
@@ -491,7 +493,13 @@ where
             for sample in ctx.take_softmax_samples() {
                 softmax_backend_stats.record(sample.backend, sample.duration);
             }
+            for sample in ctx.take_matmul_samples() {
+                matmul_backend_stats.record(sample.backend, sample.duration);
+            }
             logits_tensor = Some(qwen.output(&hidden_states, ctx)?);
+            for sample in ctx.take_matmul_samples() {
+                matmul_backend_stats.record(sample.backend, sample.duration);
+            }
             log_cache_stats(ctx, "prompt", i + 1);
         }
     }
@@ -591,6 +599,9 @@ where
         for sample in ctx.take_softmax_samples() {
             softmax_backend_stats.record(sample.backend, sample.duration);
         }
+        for sample in ctx.take_matmul_samples() {
+            matmul_backend_stats.record(sample.backend, sample.duration);
+        }
 
         if let Some(usage) = memory_snapshot.forward.last {
             latest_forward_usage = Some(usage);
@@ -628,6 +639,9 @@ where
         let output_usage_before = ctx.snapshot_memory_usage();
         let output_start = Instant::now();
         let logits_tensor = qwen.output(&hidden_states, ctx)?;
+        for sample in ctx.take_matmul_samples() {
+            matmul_backend_stats.record(sample.backend, sample.duration);
+        }
         let output_duration = output_start.elapsed();
         if !output_duration.is_zero() {
             output_stats.record(output_duration);
@@ -678,6 +692,7 @@ where
                 &embed_stats,
                 &forward_stats,
                 &block_stats,
+                &matmul_backend_stats,
                 &softmax_backend_stats,
                 &output_stats,
                 &sample_stats,

--- a/src/metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -1,4 +1,6 @@
-use super::{KernelFunction, KernelInvocable, MatMulBackend, mlx_gemm};
+use crate::metallic::kernels::KernelFunction;
+
+use super::{KernelInvocable, MatMulBackend, mlx_gemm};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};

--- a/src/metallic/kernels/matmul/mlx_gemm.rs
+++ b/src/metallic/kernels/matmul/mlx_gemm.rs
@@ -1,0 +1,359 @@
+use std::sync::OnceLock;
+
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2_foundation::NSUInteger;
+use objc2_metal::{MTLCommandBuffer, MTLComputePipelineState, MTLSize};
+
+use crate::metallic::{
+    Context, Dtype, MetalError,
+    encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_bytes_slice, set_compute_pipeline_state},
+    resource_cache::ResourceCache,
+    tensor::MpsMatrixBatchView,
+};
+
+use super::{KernelFunction, MatMulBackend, MatMulBackendKind, MpsMatMulBackend};
+
+const BM: i32 = 32;
+const BN: i32 = 32;
+const BK: i32 = 16;
+const WM: i32 = 2;
+const WN: i32 = 2;
+const SWIZZLE_LOG: i32 = 0;
+
+static MLX_GEMM_ENABLED: OnceLock<bool> = OnceLock::new();
+
+pub fn mlx_gemm_enabled() -> bool {
+    *MLX_GEMM_ENABLED.get_or_init(|| match std::env::var("METALLIC_GEMM_BACKEND") {
+        Ok(value) => {
+            let value = value.trim().to_ascii_lowercase();
+            match value.as_str() {
+                "mps" | "cpu" | "0" | "off" | "false" => false,
+                "mlx" | "1" | "on" | "true" => true,
+                _ => true,
+            }
+        }
+        Err(_) => true,
+    })
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct GemmParams {
+    m: i32,
+    n: i32,
+    k: i32,
+    lda: i32,
+    ldb: i32,
+    ldd: i32,
+    tiles_n: i32,
+    tiles_m: i32,
+    batch_stride_a: u64,
+    batch_stride_b: u64,
+    batch_stride_d: u64,
+    swizzle_log: i32,
+    gemm_k_iterations_aligned: i32,
+    batch_ndim: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct GemmAddmmParams {
+    ldc: i32,
+    fdc: i32,
+    batch_stride_c: u64,
+    alpha: f32,
+    beta: f32,
+}
+
+pub struct MlxGemmBackend {
+    pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+    m: i32,
+    n: i32,
+    k: i32,
+    lda: i32,
+    ldb: i32,
+    ldd: i32,
+    ldc: i32,
+    fdc: i32,
+    tiles_n: i32,
+    tiles_m: i32,
+    gemm_k_iterations_aligned: i32,
+    batch_size: usize,
+    batch_stride_a: u64,
+    batch_stride_b: u64,
+    batch_stride_c: Option<u64>,
+    batch_stride_d: u64,
+    alpha: f32,
+    beta: f32,
+    use_out_source: bool,
+    do_axpby: bool,
+}
+
+impl MlxGemmBackend {
+    pub fn try_new<T: crate::metallic::TensorElement>(
+        ctx: &mut Context<T>,
+        transpose_left: bool,
+        transpose_right: bool,
+        left_view: &MpsMatrixBatchView,
+        right_view: &MpsMatrixBatchView,
+        result_view: &MpsMatrixBatchView,
+        left_dtype: Dtype,
+        right_dtype: Dtype,
+        result_dtype: Dtype,
+        alpha_beta: Option<(f32, f32)>,
+    ) -> Result<Option<Self>, MetalError> {
+        if !mlx_gemm_enabled() {
+            return Ok(None);
+        }
+
+        if left_dtype != right_dtype || left_dtype != result_dtype {
+            return Ok(None);
+        }
+
+        if !matches!(left_dtype, Dtype::F32 | Dtype::F16) {
+            return Ok(None);
+        }
+
+        let elem_size = left_dtype.size_bytes();
+
+        let (m, k) = if transpose_left {
+            (left_view.columns, left_view.rows)
+        } else {
+            (left_view.rows, left_view.columns)
+        };
+        let (k_right, n) = if transpose_right {
+            (right_view.columns, right_view.rows)
+        } else {
+            (right_view.rows, right_view.columns)
+        };
+
+        if k != k_right {
+            return Err(MetalError::InvalidOperation(format!(
+                "Cannot multiply matrices (with transpose): {}x{} and {}x{}",
+                m, k, k_right, n
+            )));
+        }
+
+        let m_i32 = i32::try_from(m).map_err(|_| MetalError::OperationNotSupported("Matrix rows exceed supported limits".to_string()))?;
+        let n_i32 =
+            i32::try_from(n).map_err(|_| MetalError::OperationNotSupported("Matrix columns exceed supported limits".to_string()))?;
+        let k_i32 = i32::try_from(k)
+            .map_err(|_| MetalError::OperationNotSupported("Matrix interior dimension exceeds supported limits".to_string()))?;
+
+        let lda = Self::stride_in_elements(left_view.row_bytes, elem_size)?;
+        let ldb = Self::stride_in_elements(right_view.row_bytes, elem_size)?;
+        let ldd = Self::stride_in_elements(result_view.row_bytes, elem_size)?;
+
+        let batch_stride_a = Self::stride_in_elements_u64(left_view.matrix_bytes, elem_size)?;
+        let batch_stride_b = Self::stride_in_elements_u64(right_view.matrix_bytes, elem_size)?;
+        let batch_stride_d = Self::stride_in_elements_u64(result_view.matrix_bytes, elem_size)?;
+
+        let (alpha, beta, use_out_source, do_axpby, batch_stride_c, ldc, fdc) = if let Some((alpha, beta)) = alpha_beta {
+            let ldc = ldd;
+            let fdc = 1;
+            let batch_stride_c = batch_stride_d;
+            (alpha, beta, true, true, Some(batch_stride_c), ldc, fdc)
+        } else {
+            (1.0f32, 0.0f32, false, false, None, 0, 0)
+        };
+
+        let tiles_m = Self::ceil_div(m_i32, BM);
+        let tiles_n = Self::ceil_div(n_i32, BN);
+        let gemm_k_iterations_aligned = k_i32 / BK;
+
+        let batch_size = result_view.batch;
+
+        let kernel_fn = match (transpose_left, transpose_right) {
+            (false, false) => KernelFunction::MlxGemmNn,
+            (false, true) => KernelFunction::MlxGemmNt,
+            (true, false) => KernelFunction::MlxGemmTn,
+            (true, true) => KernelFunction::MlxGemmTt,
+        };
+
+        let pipeline = if use_out_source || do_axpby {
+            let mut flags = Vec::with_capacity(2);
+            if use_out_source {
+                flags.push((100u16, true));
+            }
+            if do_axpby {
+                flags.push((110u16, true));
+            }
+            ctx.kernel_manager
+                .get_pipeline_with_constants(kernel_fn, left_dtype, &ctx.device, Some(&flags))?
+        } else {
+            ctx.kernel_manager.get_pipeline(kernel_fn, left_dtype, &ctx.device)?
+        };
+
+        Ok(Some(Self {
+            pipeline,
+            m: m_i32,
+            n: n_i32,
+            k: k_i32,
+            lda,
+            ldb,
+            ldd,
+            ldc,
+            fdc,
+            tiles_n,
+            tiles_m,
+            gemm_k_iterations_aligned,
+            batch_size,
+            batch_stride_a,
+            batch_stride_b,
+            batch_stride_c,
+            batch_stride_d,
+            alpha,
+            beta,
+            use_out_source,
+            do_axpby,
+        }))
+    }
+
+    fn stride_in_elements(bytes: usize, elem_size: usize) -> Result<i32, MetalError> {
+        let elems = Self::stride_in_elements_u64(bytes, elem_size)?;
+        i32::try_from(elems).map_err(|_| MetalError::OperationNotSupported("Stride exceeds supported limits".to_string()))
+    }
+
+    fn stride_in_elements_u64(bytes: usize, elem_size: usize) -> Result<u64, MetalError> {
+        if bytes % elem_size != 0 {
+            return Err(MetalError::InvalidOperation(
+                "Tensor strides are not aligned to element size".to_string(),
+            ));
+        }
+        Ok((bytes / elem_size) as u64)
+    }
+
+    fn ceil_div(value: i32, divisor: i32) -> i32 {
+        (value + divisor - 1) / divisor
+    }
+
+    pub fn encode(
+        &self,
+        command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+        left_buf: &Retained<ProtocolObject<dyn objc2_metal::MTLBuffer>>,
+        left_offset: usize,
+        right_buf: &Retained<ProtocolObject<dyn objc2_metal::MTLBuffer>>,
+        right_offset: usize,
+        result_buf: &Retained<ProtocolObject<dyn objc2_metal::MTLBuffer>>,
+        result_offset: usize,
+        _cache: &mut ResourceCache,
+    ) -> Result<(), MetalError> {
+        let encoder = command_buffer
+            .computeCommandEncoder()
+            .ok_or(MetalError::ComputeEncoderCreationFailed)?;
+
+        set_compute_pipeline_state(&encoder, &self.pipeline);
+        set_buffer(&encoder, 0, left_buf, left_offset);
+        set_buffer(&encoder, 1, right_buf, right_offset);
+        if self.use_out_source {
+            set_buffer(&encoder, 2, result_buf, result_offset);
+        }
+        set_buffer(&encoder, 3, result_buf, result_offset);
+
+        let params = GemmParams {
+            m: self.m,
+            n: self.n,
+            k: self.k,
+            lda: self.lda,
+            ldb: self.ldb,
+            ldd: self.ldd,
+            tiles_n: self.tiles_n,
+            tiles_m: self.tiles_m,
+            batch_stride_a: self.batch_stride_a,
+            batch_stride_b: self.batch_stride_b,
+            batch_stride_d: self.batch_stride_d,
+            swizzle_log: SWIZZLE_LOG,
+            gemm_k_iterations_aligned: self.gemm_k_iterations_aligned,
+            batch_ndim: 1,
+        };
+        set_bytes(&encoder, 4, &params);
+
+        if self.use_out_source {
+            let addmm_params = GemmAddmmParams {
+                ldc: self.ldc,
+                fdc: self.fdc,
+                batch_stride_c: self.batch_stride_c.unwrap_or(0),
+                alpha: self.alpha,
+                beta: self.beta,
+            };
+            set_bytes(&encoder, 5, &addmm_params);
+        }
+
+        let batch_shape = [self.batch_size as i32];
+        set_bytes_slice(&encoder, 6, &batch_shape);
+
+        let mut batch_strides = [self.batch_stride_a, self.batch_stride_b, 0u64];
+        if let Some(stride_c) = self.batch_stride_c {
+            batch_strides[2] = stride_c;
+        }
+        let stride_len = if self.use_out_source { 3 } else { 2 };
+        set_bytes_slice(&encoder, 7, &batch_strides[..stride_len]);
+
+        let threads_per_tg = MTLSize {
+            width: 32,
+            height: WN as NSUInteger,
+            depth: WM as NSUInteger,
+        };
+        let groups = MTLSize {
+            width: self.tiles_n.max(1) as NSUInteger,
+            height: self.tiles_m.max(1) as NSUInteger,
+            depth: self.batch_size.max(1) as NSUInteger,
+        };
+
+        dispatch_threadgroups(&encoder, groups, threads_per_tg);
+        encoder.endEncoding();
+
+        Ok(())
+    }
+}
+
+pub fn try_create_backend<T: crate::metallic::TensorElement>(
+    ctx: &mut Context<T>,
+    cache: Option<&mut ResourceCache>,
+    transpose_left: bool,
+    transpose_right: bool,
+    left_view: &MpsMatrixBatchView,
+    right_view: &MpsMatrixBatchView,
+    result_view: &MpsMatrixBatchView,
+    left_dtype: Dtype,
+    right_dtype: Dtype,
+    result_dtype: Dtype,
+    alpha_beta: Option<(f32, f32)>,
+) -> Result<MatMulBackend, MetalError> {
+    if let Some(backend) = MlxGemmBackend::try_new(
+        ctx,
+        transpose_left,
+        transpose_right,
+        left_view,
+        right_view,
+        result_view,
+        left_dtype,
+        right_dtype,
+        result_dtype,
+        alpha_beta,
+    )? {
+        ctx.note_matmul_backend(MatMulBackendKind::Mlx);
+        return Ok(MatMulBackend::Mlx(backend));
+    }
+
+    let cache = cache.ok_or_else(|| MetalError::InvalidOperation("Resource cache required for matmul".to_string()))?;
+
+    let backend = MpsMatMulBackend::new(
+        ctx,
+        cache,
+        transpose_left,
+        transpose_right,
+        left_view,
+        right_view,
+        result_view,
+        alpha_beta.unwrap_or((1.0, 0.0)),
+        left_dtype,
+        right_dtype,
+        result_dtype,
+    )?;
+
+    ctx.note_matmul_backend(MatMulBackendKind::Mps);
+
+    Ok(MatMulBackend::Mps(backend))
+}

--- a/src/metallic/kernels/matmul/mlx_gemm.rs
+++ b/src/metallic/kernels/matmul/mlx_gemm.rs
@@ -89,7 +89,6 @@ pub struct MlxGemmBackend {
     alpha: f32,
     beta: f32,
     use_out_source: bool,
-    do_axpby: bool,
 }
 
 impl MlxGemmBackend {
@@ -216,7 +215,6 @@ impl MlxGemmBackend {
             alpha,
             beta,
             use_out_source,
-            do_axpby,
         }))
     }
 

--- a/src/metallic/kernels/matmul/mlx_gemm.rs
+++ b/src/metallic/kernels/matmul/mlx_gemm.rs
@@ -3,16 +3,17 @@ use std::sync::OnceLock;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;
-use objc2_metal::{MTLCommandBuffer, MTLComputePipelineState, MTLSize};
+use objc2_metal::{MTLCommandBuffer, MTLCommandEncoder, MTLComputePipelineState, MTLSize};
 
 use crate::metallic::{
     Context, Dtype, MetalError,
     encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_bytes_slice, set_compute_pipeline_state},
+    kernels::KernelFunction,
     resource_cache::ResourceCache,
     tensor::MpsMatrixBatchView,
 };
 
-use super::{KernelFunction, MatMulBackend, MatMulBackendKind, MpsMatMulBackend};
+use super::{MatMulBackend, MatMulBackendKind, MpsMatMulBackend};
 
 const BM: i32 = 32;
 const BN: i32 = 32;

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -1,3 +1,4 @@
+use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -1,61 +1,169 @@
-use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;
 use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrix, MPSMatrixDescriptor, MPSMatrixMultiplication};
+use std::time::Duration;
 
-use super::{KernelFunction, KernelInvocable};
+use super::KernelInvocable;
 use crate::metallic::{
-    Context, MetalError, Operation, Tensor, TensorElement, TensorInit, TensorStorage,
+    Context, Dtype, MetalError, Operation, Tensor, TensorElement, TensorInit, TensorStorage,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
+    tensor::MpsMatrixBatchView,
 };
 
 #[cfg(test)]
 mod matmul_test;
 
-// Include additional mps kernels
 mod matmul_alpha_beta;
 #[cfg(test)]
 mod matmul_alpha_beta_test;
+mod mlx_gemm;
 pub use matmul_alpha_beta::MatMulAlphaBetaOp;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MatMulBackendKind {
+    Mps,
+    Mlx,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct MatMulSample {
+    pub backend: MatMulBackendKind,
+    pub duration: Duration,
+}
+
+pub enum MatMulBackend {
+    Mps(MpsMatMulBackend),
+    Mlx(mlx_gemm::MlxGemmBackend),
+}
+
+pub struct MpsMatMulBackend {
+    left_desc: Retained<MPSMatrixDescriptor>,
+    right_desc: Retained<MPSMatrixDescriptor>,
+    result_desc: Retained<MPSMatrixDescriptor>,
+    gemm: Retained<MPSMatrixMultiplication>,
+    batch_size: usize,
+}
+
+impl MpsMatMulBackend {
+    pub fn new<T: TensorElement>(
+        ctx: &mut Context<T>,
+        cache: &mut ResourceCache,
+        transpose_left: bool,
+        transpose_right: bool,
+        left_view: &MpsMatrixBatchView,
+        right_view: &MpsMatrixBatchView,
+        result_view: &MpsMatrixBatchView,
+        alpha_beta: (f32, f32),
+        left_dtype: Dtype,
+        right_dtype: Dtype,
+        result_dtype: Dtype,
+    ) -> Result<Self, MetalError> {
+        let (alpha, beta) = alpha_beta;
+
+        let gemm_key = MpsGemmKey {
+            transpose_left,
+            transpose_right,
+            result_rows: result_view.rows,
+            result_columns: result_view.columns,
+            interior_columns: if transpose_left { left_view.rows } else { left_view.columns },
+            batch_size: result_view.batch,
+            alpha,
+            beta,
+        };
+
+        let gemm = cache.get_or_create_gemm(gemm_key, &ctx.device)?;
+
+        let left_desc_key = MpsMatrixDescriptorKey {
+            rows: left_view.rows,
+            columns: left_view.columns,
+            row_bytes: left_view.row_bytes,
+            matrices: left_view.batch,
+            matrix_bytes: left_view.matrix_bytes,
+            dtype: left_dtype,
+        };
+        let left_desc = cache.get_or_create_descriptor(left_desc_key, &ctx.device)?;
+
+        let right_desc_key = MpsMatrixDescriptorKey {
+            rows: right_view.rows,
+            columns: right_view.columns,
+            row_bytes: right_view.row_bytes,
+            matrices: right_view.batch,
+            matrix_bytes: right_view.matrix_bytes,
+            dtype: right_dtype,
+        };
+        let right_desc = cache.get_or_create_descriptor(right_desc_key, &ctx.device)?;
+
+        let result_desc_key = MpsMatrixDescriptorKey {
+            rows: result_view.rows,
+            columns: result_view.columns,
+            row_bytes: result_view.row_bytes,
+            matrices: result_view.batch,
+            matrix_bytes: result_view.matrix_bytes,
+            dtype: result_dtype,
+        };
+        let result_desc = cache.get_or_create_descriptor(result_desc_key, &ctx.device)?;
+
+        Ok(Self {
+            left_desc,
+            right_desc,
+            result_desc,
+            gemm,
+            batch_size: result_view.batch,
+        })
+    }
+
+    pub fn encode(
+        &self,
+        command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+        left_buf: &Retained<ProtocolObject<dyn MTLBuffer>>,
+        left_offset: usize,
+        right_buf: &Retained<ProtocolObject<dyn MTLBuffer>>,
+        right_offset: usize,
+        result_buf: &Retained<ProtocolObject<dyn MTLBuffer>>,
+        result_offset: usize,
+    ) -> Result<(), MetalError> {
+        let left = mps_matrix_from_buffer(left_buf, left_offset, &self.left_desc);
+        let right = mps_matrix_from_buffer(right_buf, right_offset, &self.right_desc);
+        let result = mps_matrix_from_buffer(result_buf, result_offset, &self.result_desc);
+
+        unsafe {
+            self.gemm.setBatchStart(0 as NSUInteger);
+            self.gemm.setBatchSize(self.batch_size as NSUInteger);
+        }
+        encode_mps_matrix_multiplication(&self.gemm, command_buffer, &left, &right, &result);
+
+        Ok(())
+    }
+}
 
 // Public, user-facing, zero-sized struct for the matmul operation with transpose options.
 pub struct MatMulOp;
 
 // Internal struct that holds data for the regular `Operation` trait.
 struct MatMul {
-    pub left_buf: Retained<ProtocolObject<dyn MTLBuffer>>,
-    pub left_offset: usize,
-    pub right_buf: Retained<ProtocolObject<dyn MTLBuffer>>,
-    pub right_offset: usize,
-    pub result_buf: Retained<ProtocolObject<dyn MTLBuffer>>,
-    pub result_offset: usize,
-    pub left_desc: Retained<MPSMatrixDescriptor>,
-    pub right_desc: Retained<MPSMatrixDescriptor>,
-    pub result_desc: Retained<MPSMatrixDescriptor>,
-    pub gemm: Retained<MPSMatrixMultiplication>,
-    pub batch_size: usize,
+    left_buf: Retained<ProtocolObject<dyn MTLBuffer>>,
+    left_offset: usize,
+    right_buf: Retained<ProtocolObject<dyn MTLBuffer>>,
+    right_offset: usize,
+    result_buf: Retained<ProtocolObject<dyn MTLBuffer>>,
+    result_offset: usize,
+    backend: MatMulBackend,
 }
 
-// Implement `KernelInvocable` for the public struct.
 impl KernelInvocable for MatMulOp {
-    // Input arguments for the call - two input tensors + transpose options
-    type Args<'a, T: TensorElement> = (&'a Tensor<T>, &'a Tensor<T>, bool, bool); // (left, right, transpose_left, transpose_right)
-    // The output type
+    type Args<'a, T: TensorElement> = (&'a Tensor<T>, &'a Tensor<T>, bool, bool);
 
-    // For MPS operations, return None since they don't use KernelFunction
-    fn function_id() -> Option<KernelFunction> {
-        None // MPS operations don't use kernel functions
+    fn function_id() -> Option<super::KernelFunction> {
+        None
     }
 
-    // This `new` method is called by `ctx.call()`.
-    // It creates the output tensor and the internal `Operation` struct.
     fn new<'a, T: TensorElement>(
         ctx: &mut Context<T>,
         args: Self::Args<'a, T>,
-        _pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>, // MPS doesn't use this
+        _pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor<T>), MetalError> {
         let (left, right, transpose_left, transpose_right) = args;
@@ -65,7 +173,12 @@ impl KernelInvocable for MatMulOp {
 
         ctx.prepare_tensors_for_active_cmd(&[&left_tensor, &right_tensor])?;
 
-        // Calculate effective dimensions based on transpose
+        if left_view.batch != right_view.batch {
+            return Err(MetalError::InvalidOperation(
+                "Batched matmul requires operands to share the same batch size".to_string(),
+            ));
+        }
+
         let (eff_left_rows, eff_left_cols) = if transpose_left {
             (left_view.columns, left_view.rows)
         } else {
@@ -84,13 +197,6 @@ impl KernelInvocable for MatMulOp {
             )));
         }
 
-        if left_view.batch != right_view.batch {
-            return Err(MetalError::InvalidOperation(
-                "Batched matmul requires operands to share the same batch size".to_string(),
-            ));
-        }
-
-        // Create the output tensor (eff_left_rows x eff_right_cols)
         let out_dims = if left_view.batch > 1 {
             vec![left_view.batch, eff_left_rows, eff_right_cols]
         } else {
@@ -98,6 +204,7 @@ impl KernelInvocable for MatMulOp {
         };
         let out = Tensor::new(out_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
         let result_view = out.as_mps_matrix_batch_view()?;
+
         let left_dtype = left_tensor.dtype;
         let right_dtype = right_tensor.dtype;
         let result_dtype = out.dtype;
@@ -105,118 +212,60 @@ impl KernelInvocable for MatMulOp {
         debug_assert_eq!(left_dtype, right_dtype);
         debug_assert_eq!(left_dtype, result_dtype);
 
-        let matmul_left_view = left_view;
-        let matmul_right_view = right_view;
-        let matmul_result_view = result_view;
-
-        let matmul_left_buf = left_tensor.buf.clone();
-        let matmul_left_offset = left_tensor.offset;
-        let matmul_right_buf = right_tensor.buf.clone();
-        let matmul_right_offset = right_tensor.offset;
-        let matmul_result_buf = out.buf.clone();
-        let matmul_result_offset = out.offset;
-
-        let left_desc_dtype = left_dtype;
-        let right_desc_dtype = right_dtype;
-        let result_desc_dtype = result_dtype;
-
-        // Get or create MPSMatrixMultiplication operation from cache
-        let gemm_key = MpsGemmKey {
+        let backend = mlx_gemm::try_create_backend(
+            ctx,
+            cache,
             transpose_left,
             transpose_right,
-            result_rows: eff_left_rows,
-            result_columns: eff_right_cols,
-            interior_columns: eff_left_cols, // This is the "k" dimension after applying transpose
-            batch_size: matmul_result_view.batch,
-            alpha: 1.0,
-            beta: 0.0,
-        };
+            &left_view,
+            &right_view,
+            &result_view,
+            left_dtype,
+            right_dtype,
+            result_dtype,
+            None,
+        )?;
 
-        let cache = cache.ok_or_else(|| MetalError::InvalidOperation("Resource cache required for matmul".to_string()))?;
-        let gemm = cache.get_or_create_gemm(gemm_key, &ctx.device)?;
-
-        // Create MPS matrix descriptors based on the buffers consumed by MPS
-        let left_desc_key = MpsMatrixDescriptorKey {
-            rows: matmul_left_view.rows,
-            columns: matmul_left_view.columns,
-            row_bytes: matmul_left_view.row_bytes,
-            matrices: matmul_left_view.batch,
-            matrix_bytes: matmul_left_view.matrix_bytes,
-            dtype: left_desc_dtype,
-        };
-        let left_desc = cache.get_or_create_descriptor(left_desc_key, &ctx.device)?;
-
-        let right_desc_key = MpsMatrixDescriptorKey {
-            rows: matmul_right_view.rows,
-            columns: matmul_right_view.columns,
-            row_bytes: matmul_right_view.row_bytes,
-            matrices: matmul_right_view.batch,
-            matrix_bytes: matmul_right_view.matrix_bytes,
-            dtype: right_desc_dtype,
-        };
-        let right_desc = cache.get_or_create_descriptor(right_desc_key, &ctx.device)?;
-
-        let result_desc_key = MpsMatrixDescriptorKey {
-            rows: eff_left_rows,
-            columns: eff_right_cols,
-            row_bytes: matmul_result_view.row_bytes,
-            matrices: matmul_result_view.batch,
-            matrix_bytes: matmul_result_view.matrix_bytes,
-            dtype: result_desc_dtype,
-        };
-        let result_desc = cache.get_or_create_descriptor(result_desc_key, &ctx.device)?;
-
-        // Create the internal operation struct.
         let op = MatMul {
-            left_buf: matmul_left_buf,
-            left_offset: matmul_left_offset,
-            right_buf: matmul_right_buf,
-            right_offset: matmul_right_offset,
-            result_buf: matmul_result_buf,
-            result_offset: matmul_result_offset,
-            left_desc,
-            right_desc,
-            result_desc,
-            gemm,
-            batch_size: matmul_result_view.batch,
+            left_buf: left_tensor.buf.clone(),
+            left_offset: left_tensor.offset,
+            right_buf: right_tensor.buf.clone(),
+            right_offset: right_tensor.offset,
+            result_buf: out.buf.clone(),
+            result_offset: out.offset,
+            backend,
         };
 
-        // Return the boxed operation and the output tensor.
         Ok((Box::new(op), out))
     }
 }
 
-// Implement `Operation` for the internal struct.
-// This contains the low-level logic to encode the kernel onto the command buffer.
 impl Operation for MatMul {
-    fn encode(
-        &self,
-        command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,
-        _cache: &mut ResourceCache,
-    ) -> Result<(), MetalError> {
-        // Wrap buffers into MPSMatrix views
-        let left = mps_matrix_from_buffer(&self.left_buf, self.left_offset, &self.left_desc);
-        let right = mps_matrix_from_buffer(&self.right_buf, self.right_offset, &self.right_desc);
-        let result = mps_matrix_from_buffer(&self.result_buf, self.result_offset, &self.result_desc);
-
-        // Encode the MPS matrix multiplication
-        unsafe {
-            self.gemm.setBatchStart(0 as NSUInteger);
-            self.gemm.setBatchSize(self.batch_size as NSUInteger);
+    fn encode(&self, command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>, cache: &mut ResourceCache) -> Result<(), MetalError> {
+        match &self.backend {
+            MatMulBackend::Mps(backend) => backend.encode(
+                command_buffer,
+                &self.left_buf,
+                self.left_offset,
+                &self.right_buf,
+                self.right_offset,
+                &self.result_buf,
+                self.result_offset,
+            ),
+            MatMulBackend::Mlx(backend) => backend.encode(
+                command_buffer,
+                &self.left_buf,
+                self.left_offset,
+                &self.right_buf,
+                self.right_offset,
+                &self.result_buf,
+                self.result_offset,
+                cache,
+            ),
         }
-        encode_mps_matrix_multiplication(&self.gemm, command_buffer, &left, &right, &result);
-
-        Ok(())
     }
 }
 
-/// Create an `MPSMatrix` view into an existing `MTLBuffer`.
-///
-/// # Arguments
-///
-/// * `buffer` - The retained Metal buffer containing f32 elements.
-/// * `offset` - A byte offset into the buffer where the matrix data begins.
-/// * `descriptor` - Describes the matrix layout (rows, columns, rowBytes).
 pub fn mps_matrix_from_buffer(
     buffer: &Retained<ProtocolObject<dyn MTLBuffer>>,
     offset: usize,
@@ -236,15 +285,6 @@ pub fn mps_matrix_from_buffer(
     unsafe { MPSMatrix::initWithBuffer_offset_descriptor(MPSMatrix::alloc(), buffer, offset, descriptor) }
 }
 
-/// Encodes a matrix multiplication operation to a command buffer.
-///
-/// # Arguments
-///
-/// * `op` - The `MPSMatrixMultiplication` operation to encode.
-/// * `command_buffer` - The command buffer to encode the operation into.
-/// * `left` - The left matrix operand.
-/// * `right` - The right matrix operand.
-/// * `result` - The result matrix.
 pub fn encode_mps_matrix_multiplication(
     op: &Retained<MPSMatrixMultiplication>,
     command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -192,7 +192,7 @@ impl KernelFunction {
                     "gemm_nn_f16_f16_32_32_16_2_2"
                 }
             }
-            (KernelFunction::MlxGemmNn, dtype) => {
+            (KernelFunction::MlxGemmNn, dtype) if !matches!(dtype, F32 | F16) => {
                 return Err(MetalError::UnsupportedDtype {
                     operation: "MLX GEMM",
                     dtype,
@@ -205,7 +205,7 @@ impl KernelFunction {
                     "gemm_nt_f16_f16_32_32_16_2_2"
                 }
             }
-            (KernelFunction::MlxGemmNt, dtype) => {
+            (KernelFunction::MlxGemmNt, dtype) if !matches!(dtype, F32 | F16) => {
                 return Err(MetalError::UnsupportedDtype {
                     operation: "MLX GEMM",
                     dtype,
@@ -218,7 +218,7 @@ impl KernelFunction {
                     "gemm_tn_f16_f16_32_32_16_2_2"
                 }
             }
-            (KernelFunction::MlxGemmTn, dtype) => {
+            (KernelFunction::MlxGemmTn, dtype) if !matches!(dtype, F32 | F16) => {
                 return Err(MetalError::UnsupportedDtype {
                     operation: "MLX GEMM",
                     dtype,
@@ -231,7 +231,7 @@ impl KernelFunction {
                     "gemm_tt_f16_f16_32_32_16_2_2"
                 }
             }
-            (KernelFunction::MlxGemmTt, dtype) => {
+            (KernelFunction::MlxGemmTt, dtype) if !matches!(dtype, F32 | F16) => {
                 return Err(MetalError::UnsupportedDtype {
                     operation: "MLX GEMM",
                     dtype,

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -196,7 +196,9 @@ impl KernelFunction {
             (KernelFunction::MlxGemmNn, dtype)
             | (KernelFunction::MlxGemmNt, dtype)
             | (KernelFunction::MlxGemmTn, dtype)
-            | (KernelFunction::MlxGemmTt, dtype) => {
+            | (KernelFunction::MlxGemmTt, dtype)
+                if !matches!(dtype, F32 | F16) =>
+            {
                 return Err(MetalError::UnsupportedDtype {
                     operation: "MLX GEMM",
                     dtype,

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -185,25 +185,46 @@ impl KernelFunction {
             (KernelFunction::Ones, F16) => "ones_kernel_f16",
             (KernelFunction::RandomUniform, F32) => "random_uniform_f32",
             (KernelFunction::RandomUniform, F16) => "random_uniform_f16",
-            (KernelFunction::MlxGemmNn, F32) => "gemm_nn_f32_f32_32_32_16_2_2",
-            (KernelFunction::MlxGemmNn, F16) => "gemm_nn_f16_f16_32_32_16_2_2",
-            (KernelFunction::MlxGemmNt, F32) => "gemm_nt_f32_f32_32_32_16_2_2",
-            (KernelFunction::MlxGemmNt, F16) => "gemm_nt_f16_f16_32_32_16_2_2",
-            (KernelFunction::MlxGemmTn, F32) => "gemm_tn_f32_f32_32_32_16_2_2",
-            (KernelFunction::MlxGemmTn, F16) => "gemm_tn_f16_f16_32_32_16_2_2",
-            (KernelFunction::MlxGemmTt, F32) => "gemm_tt_f32_f32_32_32_16_2_2",
-            (KernelFunction::MlxGemmTt, F16) => "gemm_tt_f16_f16_32_32_16_2_2",
-            (KernelFunction::MlxGemmNn, dtype)
-            | (KernelFunction::MlxGemmNt, dtype)
-            | (KernelFunction::MlxGemmTn, dtype)
-            | (KernelFunction::MlxGemmTt, dtype)
-                if !matches!(dtype, F32 | F16) =>
-            {
-                return Err(MetalError::UnsupportedDtype {
-                    operation: "MLX GEMM",
-                    dtype,
-                });
-            }
+            (KernelFunction::MlxGemmNn, dtype) => match dtype {
+                F32 => "gemm_nn_f32_f32_32_32_16_2_2",
+                F16 => "gemm_nn_f16_f16_32_32_16_2_2",
+                other => {
+                    return Err(MetalError::UnsupportedDtype {
+                        operation: "MLX GEMM",
+                        dtype: other,
+                    });
+                }
+            },
+            (KernelFunction::MlxGemmNt, dtype) => match dtype {
+                F32 => "gemm_nt_f32_f32_32_32_16_2_2",
+                F16 => "gemm_nt_f16_f16_32_32_16_2_2",
+                other => {
+                    return Err(MetalError::UnsupportedDtype {
+                        operation: "MLX GEMM",
+                        dtype: other,
+                    });
+                }
+            },
+            (KernelFunction::MlxGemmTn, dtype) => match dtype {
+                F32 => "gemm_tn_f32_f32_32_32_16_2_2",
+                F16 => "gemm_tn_f16_f16_32_32_16_2_2",
+                other => {
+                    return Err(MetalError::UnsupportedDtype {
+                        operation: "MLX GEMM",
+                        dtype: other,
+                    });
+                }
+            },
+            (KernelFunction::MlxGemmTt, dtype) => match dtype {
+                F32 => "gemm_tt_f32_f32_32_32_16_2_2",
+                F16 => "gemm_tt_f16_f16_32_32_16_2_2",
+                other => {
+                    return Err(MetalError::UnsupportedDtype {
+                        operation: "MLX GEMM",
+                        dtype: other,
+                    });
+                }
+            },
         };
 
         Ok(name)

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -185,46 +185,58 @@ impl KernelFunction {
             (KernelFunction::Ones, F16) => "ones_kernel_f16",
             (KernelFunction::RandomUniform, F32) => "random_uniform_f32",
             (KernelFunction::RandomUniform, F16) => "random_uniform_f16",
-            (KernelFunction::MlxGemmNn, dtype) => match dtype {
-                F32 => "gemm_nn_f32_f32_32_32_16_2_2",
-                F16 => "gemm_nn_f16_f16_32_32_16_2_2",
-                other => {
-                    return Err(MetalError::UnsupportedDtype {
-                        operation: "MLX GEMM",
-                        dtype: other,
-                    });
+            (KernelFunction::MlxGemmNn, dtype @ (F32 | F16)) => {
+                if dtype == F32 {
+                    "gemm_nn_f32_f32_32_32_16_2_2"
+                } else {
+                    "gemm_nn_f16_f16_32_32_16_2_2"
                 }
-            },
-            (KernelFunction::MlxGemmNt, dtype) => match dtype {
-                F32 => "gemm_nt_f32_f32_32_32_16_2_2",
-                F16 => "gemm_nt_f16_f16_32_32_16_2_2",
-                other => {
-                    return Err(MetalError::UnsupportedDtype {
-                        operation: "MLX GEMM",
-                        dtype: other,
-                    });
+            }
+            (KernelFunction::MlxGemmNn, dtype) => {
+                return Err(MetalError::UnsupportedDtype {
+                    operation: "MLX GEMM",
+                    dtype,
+                });
+            }
+            (KernelFunction::MlxGemmNt, dtype @ (F32 | F16)) => {
+                if dtype == F32 {
+                    "gemm_nt_f32_f32_32_32_16_2_2"
+                } else {
+                    "gemm_nt_f16_f16_32_32_16_2_2"
                 }
-            },
-            (KernelFunction::MlxGemmTn, dtype) => match dtype {
-                F32 => "gemm_tn_f32_f32_32_32_16_2_2",
-                F16 => "gemm_tn_f16_f16_32_32_16_2_2",
-                other => {
-                    return Err(MetalError::UnsupportedDtype {
-                        operation: "MLX GEMM",
-                        dtype: other,
-                    });
+            }
+            (KernelFunction::MlxGemmNt, dtype) => {
+                return Err(MetalError::UnsupportedDtype {
+                    operation: "MLX GEMM",
+                    dtype,
+                });
+            }
+            (KernelFunction::MlxGemmTn, dtype @ (F32 | F16)) => {
+                if dtype == F32 {
+                    "gemm_tn_f32_f32_32_32_16_2_2"
+                } else {
+                    "gemm_tn_f16_f16_32_32_16_2_2"
                 }
-            },
-            (KernelFunction::MlxGemmTt, dtype) => match dtype {
-                F32 => "gemm_tt_f32_f32_32_32_16_2_2",
-                F16 => "gemm_tt_f16_f16_32_32_16_2_2",
-                other => {
-                    return Err(MetalError::UnsupportedDtype {
-                        operation: "MLX GEMM",
-                        dtype: other,
-                    });
+            }
+            (KernelFunction::MlxGemmTn, dtype) => {
+                return Err(MetalError::UnsupportedDtype {
+                    operation: "MLX GEMM",
+                    dtype,
+                });
+            }
+            (KernelFunction::MlxGemmTt, dtype @ (F32 | F16)) => {
+                if dtype == F32 {
+                    "gemm_tt_f32_f32_32_32_16_2_2"
+                } else {
+                    "gemm_tt_f16_f16_32_32_16_2_2"
                 }
-            },
+            }
+            (KernelFunction::MlxGemmTt, dtype) => {
+                return Err(MetalError::UnsupportedDtype {
+                    operation: "MLX GEMM",
+                    dtype,
+                });
+            }
         };
 
         Ok(name)


### PR DESCRIPTION
## Summary
- expose MatMul backend metadata so the context can record which implementation executes
- feed matmul backend samples into the generation metrics pipeline and surface new latency rows
- document how to benchmark the MLX GEMM path alongside the legacy MPS fallback

## Testing
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68dd647907d88326b401db70c6429006