### PR TITLE
Enable MLX matmul for transposed operands

### DIFF
--- a/src/metallic/kernels/matmul/matmul_test.rs
+++ b/src/metallic/kernels/matmul/matmul_test.rs
@@ -333,9 +333,15 @@ fn verify_mlx_backend_for_transpose(transpose_left: bool, transpose_right: bool)
     let actual = mlx_result.to_vec();
     let mlx_samples = context.take_matmul_samples();
     assert!(!mlx_samples.is_empty(), "expected MLX dispatches to produce backend samples");
+    let expected_backend = if transpose_left || transpose_right {
+        MatMulBackend::MlxTransposed
+    } else {
+        MatMulBackend::Mlx
+    };
     assert!(
-        mlx_samples.iter().all(|sample| sample.backend == MatMulBackend::Mlx),
-        "expected MLX backend but observed {:?}",
+        mlx_samples.iter().all(|sample| sample.backend == expected_backend),
+        "expected MLX backend {:?} but observed {:?}",
+        expected_backend,
         mlx_samples.iter().map(|sample| sample.backend).collect::<Vec<_>>()
     );
 

--- a/src/metallic/kernels/matmul/matmul_test.rs
+++ b/src/metallic/kernels/matmul/matmul_test.rs
@@ -1,4 +1,4 @@
-use crate::metallic::kernels::matmul::{MatMulAlphaBetaOp, MatMulOp, mps_matrix_from_buffer};
+use crate::metallic::kernels::matmul::{MatMulAlphaBetaOp, MatMulBackend, MatMulBackendPreference, MatMulOp, mps_matrix_from_buffer};
 use crate::metallic::{Context, F32Element, MetalError, Tensor, TensorInit, TensorStorage};
 
 // Helpers
@@ -291,6 +291,85 @@ fn test_matmul_transpose_left() -> Result<(), MetalError> {
         );
     }
 
+    Ok(())
+}
+
+fn verify_mlx_backend_for_transpose(transpose_left: bool, transpose_right: bool) -> Result<(), MetalError> {
+    let mut context = Context::<F32Element>::new()?;
+    let m = 4;
+    let k = 5;
+    let n = 3;
+
+    let (left_rows, left_cols) = if transpose_left { (k, m) } else { (m, k) };
+    let (right_rows, right_cols) = if transpose_right { (n, k) } else { (k, n) };
+
+    let left_data: Vec<f32> = (0..(left_rows * left_cols)).map(|i| (i as f32) * 0.03125 + 0.25).collect();
+    let right_data: Vec<f32> = (0..(right_rows * right_cols)).map(|i| 1.0 - (i as f32) * 0.0175).collect();
+
+    let left_tensor = Tensor::new(
+        vec![left_rows, left_cols],
+        TensorStorage::Dedicated(&context),
+        TensorInit::CopyFrom(&left_data),
+    )?;
+    let right_tensor = Tensor::new(
+        vec![right_rows, right_cols],
+        TensorStorage::Dedicated(&context),
+        TensorInit::CopyFrom(&right_data),
+    )?;
+
+    context.set_matmul_backend_preference(MatMulBackendPreference::ForceMps);
+    let mps_result = context.call::<MatMulOp>((&left_tensor, &right_tensor, transpose_left, transpose_right))?;
+    context.synchronize();
+    let expected = mps_result.to_vec();
+    let mps_samples = context.take_matmul_samples();
+    assert!(
+        mps_samples.iter().all(|sample| sample.backend == MatMulBackend::Mps),
+        "expected ForceMps dispatches to use the MPS backend"
+    );
+
+    context.set_matmul_backend_preference(MatMulBackendPreference::ForceMlx);
+    let mlx_result = context.call::<MatMulOp>((&left_tensor, &right_tensor, transpose_left, transpose_right))?;
+    context.synchronize();
+    let actual = mlx_result.to_vec();
+    let mlx_samples = context.take_matmul_samples();
+    assert!(!mlx_samples.is_empty(), "expected MLX dispatches to produce backend samples");
+    assert!(
+        mlx_samples.iter().all(|sample| sample.backend == MatMulBackend::Mlx),
+        "expected MLX backend but observed {:?}",
+        mlx_samples.iter().map(|sample| sample.backend).collect::<Vec<_>>()
+    );
+
+    assert_eq!(expected.len(), actual.len());
+    let rtol = 1e-4f32;
+    let atol = 1e-6f32;
+    for (idx, (&expected_val, &actual_val)) in expected.iter().zip(actual.iter()).enumerate() {
+        let diff = (expected_val - actual_val).abs();
+        let rel = if expected_val.abs() > 1e-6 {
+            diff / expected_val.abs()
+        } else {
+            diff
+        };
+        assert!(
+            diff <= atol || rel <= rtol,
+            "Mismatch at index {} for transpose_left={}, transpose_right={} (expected {}, got {}, diff {}, rel {})",
+            idx,
+            transpose_left,
+            transpose_right,
+            expected_val,
+            actual_val,
+            diff,
+            rel
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_mlx_backend_handles_transposed_inputs() -> Result<(), MetalError> {
+    for &(transpose_left, transpose_right) in &[(true, false), (false, true), (true, true)] {
+        verify_mlx_backend_for_transpose(transpose_left, transpose_right)?;
+    }
     Ok(())
 }
 

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -29,6 +29,7 @@ pub use matmul_alpha_beta::MatMulAlphaBetaOp;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum MatMulBackend {
+    Total,
     Mps,
     Mlx,
     MlxTransposed,

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -31,6 +31,7 @@ pub use matmul_alpha_beta::MatMulAlphaBetaOp;
 pub enum MatMulBackend {
     Mps,
     Mlx,
+    MlxTransposed,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -388,7 +389,11 @@ impl KernelInvocable for MatMulOp {
                 transpose_right,
             ) {
                 Ok(mlx_op) => {
-                    selected_backend = MatMulBackend::Mlx;
+                    selected_backend = if transpose_left || transpose_right {
+                        MatMulBackend::MlxTransposed
+                    } else {
+                        MatMulBackend::Mlx
+                    };
                     implementation = Some(MatMulImplementation::Mlx(mlx_op));
                 }
                 Err(err) => {

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -189,6 +189,7 @@ impl MatMulMlx {
         result: &Tensor<T>,
         left_view: MpsMatrixBatchView,
         right_view: MpsMatrixBatchView,
+        result_view: MpsMatrixBatchView,
         eff_left_rows: usize,
         eff_left_cols: usize,
         eff_right_cols: usize,
@@ -200,6 +201,7 @@ impl MatMulMlx {
         let k = eff_left_cols;
 
         debug_assert_eq!(left_view.batch, right_view.batch);
+        debug_assert_eq!(left_view.batch, result_view.batch);
 
         let align_m = m % 32 == 0;
         let align_n = n % 32 == 0;
@@ -223,9 +225,23 @@ impl MatMulMlx {
         let k_i32 =
             i32::try_from(k).map_err(|_| MetalError::InvalidOperation("matmul interior dimension exceeds i32 range".to_string()))?;
 
-        let lda = i32::try_from(k).map_err(|_| MetalError::InvalidOperation("lda exceeds i32 range".to_string()))?;
-        let ldb = i32::try_from(n).map_err(|_| MetalError::InvalidOperation("ldb exceeds i32 range".to_string()))?;
-        let ldd = ldb;
+        let left_elem_size = left_tensor.dtype.size_bytes();
+        let right_elem_size = right_tensor.dtype.size_bytes();
+        let result_elem_size = result.dtype.size_bytes();
+
+        debug_assert_eq!(left_elem_size, right_elem_size);
+        debug_assert_eq!(left_elem_size, result_elem_size);
+
+        let (left_row_stride, left_matrix_stride) = matrix_strides_from_view(&left_view, left_elem_size)
+            .ok_or_else(|| MetalError::InvalidOperation("MatMul MLX backend requires contiguous left operand".to_string()))?;
+        let (right_row_stride, right_matrix_stride) = matrix_strides_from_view(&right_view, right_elem_size)
+            .ok_or_else(|| MetalError::InvalidOperation("MatMul MLX backend requires contiguous right operand".to_string()))?;
+        let (result_row_stride, result_matrix_stride) = matrix_strides_from_view(&result_view, result_elem_size)
+            .ok_or_else(|| MetalError::InvalidOperation("MatMul MLX backend requires contiguous result tensor".to_string()))?;
+
+        let lda = i32::try_from(left_row_stride).map_err(|_| MetalError::InvalidOperation("lda exceeds i32 range".to_string()))?;
+        let ldb = i32::try_from(right_row_stride).map_err(|_| MetalError::InvalidOperation("ldb exceeds i32 range".to_string()))?;
+        let ldd = i32::try_from(result_row_stride).map_err(|_| MetalError::InvalidOperation("ldd exceeds i32 range".to_string()))?;
 
         let bm = 32usize;
         let bn = 32usize;
@@ -235,20 +251,9 @@ impl MatMulMlx {
         let tiles_n = n.div_ceil(bn) * tile;
         let tiles_m = m.div_ceil(bm).div_ceil(tile);
 
-        let batch_stride_a_elems = if left_tensor.dims.len() > 2 {
-            left_tensor.strides[left_tensor.strides.len() - 3]
-        } else {
-            m * k
-        };
-        let batch_stride_b_elems = if right_tensor.dims.len() > 2 {
-            right_tensor.strides[right_tensor.strides.len() - 3]
-        } else {
-            n * k
-        };
-
-        let batch_stride_a = batch_stride_a_elems;
-        let batch_stride_b = batch_stride_b_elems;
-        let batch_stride_d = m * n;
+        let batch_stride_a = left_matrix_stride;
+        let batch_stride_b = right_matrix_stride;
+        let batch_stride_d = result_matrix_stride;
 
         let params = GemmParams {
             m: m_i32,
@@ -367,7 +372,7 @@ impl KernelInvocable for MatMulOp {
         let mut selected_backend = MatMulBackend::Mps;
         let mut implementation: Option<MatMulImplementation> = None;
 
-        if preference != MatMulBackendPreference::ForceMps && supports_mlx(&left_tensor, &right_tensor, transpose_left, transpose_right) {
+        if preference != MatMulBackendPreference::ForceMps && supports_mlx(&left_tensor, &left_view, &right_tensor, &right_view) {
             match MatMulMlx::new(
                 ctx,
                 &left_tensor,
@@ -375,6 +380,7 @@ impl KernelInvocable for MatMulOp {
                 &out,
                 left_view,
                 right_view,
+                result_view,
                 eff_left_rows,
                 eff_left_cols,
                 eff_right_cols,
@@ -393,7 +399,7 @@ impl KernelInvocable for MatMulOp {
             }
         } else if preference == MatMulBackendPreference::ForceMlx {
             return Err(MetalError::OperationNotSupported(
-                "MatMul MLX backend requires contiguous non-transposed inputs".to_string(),
+                "MatMul MLX backend requires contiguous inputs".to_string(),
             ));
         }
 
@@ -554,11 +560,12 @@ pub fn encode_mps_matrix_multiplication(
 
 /// Returns true when the MLX kernel can service the requested matmul without
 /// additional data movement.
-fn supports_mlx<T: TensorElement>(left: &Tensor<T>, right: &Tensor<T>, transpose_left: bool, transpose_right: bool) -> bool {
-    if transpose_left || transpose_right {
-        return false;
-    }
-
+fn supports_mlx<T: TensorElement>(
+    left: &Tensor<T>,
+    left_view: &MpsMatrixBatchView,
+    right: &Tensor<T>,
+    right_view: &MpsMatrixBatchView,
+) -> bool {
     if left.dtype != right.dtype {
         return false;
     }
@@ -566,14 +573,52 @@ fn supports_mlx<T: TensorElement>(left: &Tensor<T>, right: &Tensor<T>, transpose
     matches!(
         left.dtype,
         crate::metallic::tensor::Dtype::F16 | crate::metallic::tensor::Dtype::F32
-    ) && is_row_major(left)
-        && is_row_major(right)
+    ) && mlx_operand_is_contiguous(left, left_view)
+        && mlx_operand_is_contiguous(right, right_view)
 }
 
-fn is_row_major<T: TensorElement>(tensor: &Tensor<T>) -> bool {
+fn mlx_operand_is_contiguous<T: TensorElement>(tensor: &Tensor<T>, view: &MpsMatrixBatchView) -> bool {
     if tensor.dims().len() < 2 {
         return false;
     }
 
-    tensor.strides == Tensor::<T>::compute_strides(tensor.dims())
+    let elem_size = tensor.dtype.size_bytes();
+    let Some((row_stride, matrix_stride)) = matrix_strides_from_view(view, elem_size) else {
+        return false;
+    };
+
+    if row_stride != view.columns {
+        return false;
+    }
+
+    let Some(expected_matrix_stride) = view.rows.checked_mul(row_stride) else {
+        return false;
+    };
+    if matrix_stride != expected_matrix_stride {
+        return false;
+    }
+
+    matches!(tensor.strides.last(), Some(1))
+}
+
+fn matrix_strides_from_view(view: &MpsMatrixBatchView, elem_size: usize) -> Option<(usize, usize)> {
+    if elem_size == 0 {
+        return None;
+    }
+
+    if view.row_bytes % elem_size != 0 {
+        return None;
+    }
+
+    let row_stride = view.row_bytes / elem_size;
+
+    if view.matrix_bytes == 0 {
+        let matrix_stride = view.rows.checked_mul(row_stride)?;
+        Some((row_stride, matrix_stride))
+    } else {
+        if view.matrix_bytes % elem_size != 0 {
+            return None;
+        }
+        Some((row_stride, view.matrix_bytes / elem_size))
+    }
 }

--- a/src/metallic/metrics.rs
+++ b/src/metallic/metrics.rs
@@ -89,6 +89,7 @@ impl RollingStat {
 pub struct MatMulBackendStats {
     mps: RollingStat,
     mlx: RollingStat,
+    mlx_transposed: RollingStat,
 }
 
 impl MatMulBackendStats {
@@ -96,6 +97,7 @@ impl MatMulBackendStats {
         match backend {
             MatMulBackend::Mps => self.mps.record(duration),
             MatMulBackend::Mlx => self.mlx.record(duration),
+            MatMulBackend::MlxTransposed => self.mlx_transposed.record(duration),
         }
     }
 
@@ -105,6 +107,10 @@ impl MatMulBackendStats {
 
     pub fn mlx(&self) -> &RollingStat {
         &self.mlx
+    }
+
+    pub fn mlx_transposed(&self) -> &RollingStat {
+        &self.mlx_transposed
     }
 }
 
@@ -538,6 +544,15 @@ pub fn build_latency_rows(
             label: "MatMul (MLX)".to_string(),
             last_ms: matmul.mlx().last_ms(),
             average_ms: matmul.mlx().average_ms(),
+            level: 0,
+        });
+    }
+
+    if matmul.mlx_transposed().has_samples() {
+        rows.push(LatencyRow {
+            label: "MatMul (MLX, transposed)".to_string(),
+            last_ms: matmul.mlx_transposed().last_ms(),
+            average_ms: matmul.mlx_transposed().average_ms(),
             level: 0,
         });
     }

--- a/src/metallic/metrics.rs
+++ b/src/metallic/metrics.rs
@@ -87,6 +87,7 @@ impl RollingStat {
 
 #[derive(Clone, Default)]
 pub struct MatMulBackendStats {
+    total: RollingStat,
     mps: RollingStat,
     mlx: RollingStat,
     mlx_transposed: RollingStat,
@@ -95,10 +96,15 @@ pub struct MatMulBackendStats {
 impl MatMulBackendStats {
     pub fn record(&mut self, backend: MatMulBackend, duration: Duration) {
         match backend {
+            MatMulBackend::Total => self.total.record(duration),
             MatMulBackend::Mps => self.mps.record(duration),
             MatMulBackend::Mlx => self.mlx.record(duration),
             MatMulBackend::MlxTransposed => self.mlx_transposed.record(duration),
         }
+    }
+
+    pub fn total(&self) -> &RollingStat {
+        &self.total
     }
 
     pub fn mps(&self) -> &RollingStat {
@@ -529,6 +535,15 @@ pub fn build_latency_rows(
         average_ms: forward.average_ms(),
         level: 0,
     });
+
+    if matmul.total().has_samples() {
+        rows.push(LatencyRow {
+            label: "MatMul (total)".to_string(),
+            last_ms: matmul.total().last_ms(),
+            average_ms: matmul.total().average_ms(),
+            level: 0,
+        });
+    }
 
     if matmul.mps().has_samples() {
         rows.push(LatencyRow {

--- a/src/metallic/tests/generation_test.rs
+++ b/src/metallic/tests/generation_test.rs
@@ -229,6 +229,10 @@ fn matmul_sample_aggregation_sums_backend_totals() {
             backend: MatMulBackend::Mlx,
             duration: Duration::from_millis(5),
         },
+        MatMulSample {
+            backend: MatMulBackend::MlxTransposed,
+            duration: Duration::from_millis(7),
+        },
     ]);
 
     let total = totals
@@ -242,7 +246,12 @@ fn matmul_sample_aggregation_sums_backend_totals() {
         .copied()
         .expect("aggregated totals should include the MLX backend");
     assert_eq!(mlx_total, Duration::from_millis(5));
-    assert_eq!(totals.len(), 2);
+    let mlx_transposed_total = totals
+        .get(&MatMulBackend::MlxTransposed)
+        .copied()
+        .expect("aggregated totals should include the MLX transposed backend");
+    assert_eq!(mlx_transposed_total, Duration::from_millis(7));
+    assert_eq!(totals.len(), 3);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow the MLX matmul backend to reuse contiguous transposed operands by deriving strides from matrix views
- update the MLX matmul parameter setup so stride and batching values match the requested layout
- add regression tests that force the MLX backend for transposed combinations and compare against the MPS output

## Testing
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68ddb53bdae48326a50ef6f14139f589