### PR TITLE
Align Qwen2.5 loader tensor orientations

### DIFF
--- a/src/metallic/models/qwen25/loading.rs
+++ b/src/metallic/models/qwen25/loading.rs
@@ -164,7 +164,11 @@ fn copy_tensor_transposed_into<TSrc: TensorElement, TDst: TensorElement>(
     }
 
     let src_slice = tensor_data_as_f32(src);
-    copy_transposed_f32_into_slice::<TDst>(src_slice.as_ref(), src.dims(), dst.as_mut_slice(), dst.dims())
+    let src_dims = src.dims().to_vec();
+    let dst_dims = dst.dims().to_vec();
+    let dst_slice = dst.as_mut_slice();
+
+    copy_transposed_f32_into_slice::<TDst>(src_slice.as_ref(), &src_dims, dst_slice, &dst_dims)
 }
 
 fn copy_tensor_with_optional_transpose<TSrc: TensorElement, TDst: TensorElement>(


### PR DESCRIPTION
## Summary
- add a reusable helper that materializes a transposed view of GGUF tensors when copying into Metal tensors
- store lm_head and FFN weights in the new fast-GEMM orientation at load time, including fused gate/up buffers and weight tying
- extend loader unit tests to cover the updated layouts for both row-major and column-major exports

## Testing
- Not run (Metal/MPS runtime unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de98869fa4832680560f115a5a4fb4