### PR TITLE
Drop transpose fallback for Qwen25 matmuls

### DIFF
--- a/src/metallic/models/qwen25/mod.rs
+++ b/src/metallic/models/qwen25/mod.rs
@@ -295,12 +295,7 @@ impl<T: TensorElement> Qwen25<T> {
                 .reshape(vec![batch, seq, d_model])?;
 
             let attn_out = ctx
-                .matmul(
-                    &attn_out_reshaped.reshape(vec![m, d_model])?,
-                    &block.attn_out_weight,
-                    false,
-                    true, // Transpose the output weight for correct dimensions
-                )?
+                .matmul(&attn_out_reshaped.reshape(vec![m, d_model])?, &block.attn_out_weight, false, false)?
                 .reshape(vec![batch, seq, d_model])?;
 
             // Residual Add
@@ -470,7 +465,7 @@ impl<T: TensorElement> Qwen25<T> {
             let attn_out_reshaped = attn_out_permuted.reshape(vec![batch, seq, d_model])?;
 
             let attn_out = ctx
-                .matmul(&attn_out_reshaped.reshape(vec![m, d_model])?, &block.attn_out_weight, false, true)?
+                .matmul(&attn_out_reshaped.reshape(vec![m, d_model])?, &block.attn_out_weight, false, false)?
                 .reshape(vec![batch, seq, d_model])?;
 
             // Residual Add


### PR DESCRIPTION
## Summary
- update Qwen25 attention output matmuls to use pre-transposed weight buffers directly
- enforce the new `[d_model, 2 * ff_dim]` / `[d_model, ff_dim]` / `[ff_dim, d_model]` layouts inside the SwiGLU composite
- align forward pass correctness diagnostics with the non-transposed weight orientation

## Testing
- cargo fmt
- not run (Metal-dependent build/test environment unavailable in sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68de9c5998ec83268e82104b23fec641