### PR TITLE
Assert Qwen FFN matmul layout and guard against transposed backends

### DIFF
--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -26,3 +26,4 @@ The following are design goals and rules for our Agents and Developers for the p
 23. Unit tests should have strict tollerances and we should avoid adjusting tests to work around issues, and instead fix issues if the tests are valid.
 24. Please remember to context.synchronize() as needed to make sure that tensors are settled in the gpu memory when created or used.
 25. If updating code that has comments that reference it make sure the comments are updated to match the new changes.
+26. Qwen-family FFN weights are expected to be stored pre-transposed with gate/up matrices shaped `[d_model, ff_dim]` and down matrices shaped `[ff_dim, d_model]`. Weight loaders must honor this layout so runtime matmuls can execute without transpose flags.


### PR DESCRIPTION
## Summary
- clarify the FFN debug prints to call out the expected [d_model, ff_dim] / [ff_dim, d_model] weight layouts and assert that all matmuls run without transpose flags
- drain matmul instrumentation around the Qwen forward pass and fail the test if an MlxTransposed backend is observed
- document the pre-transposed Qwen FFN weight contract in PROJECT_RULES.md for future loaders

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68de9e2c587c832693eff24fedf04386