### PR TITLE
Add MLX matmul latency metrics row

### DIFF
--- a/src/metallic/metrics.rs
+++ b/src/metallic/metrics.rs
@@ -533,6 +533,15 @@ pub fn build_latency_rows(
         });
     }
 
+    if matmul.mlx().has_samples() {
+        rows.push(LatencyRow {
+            label: "MatMul (MLX)".to_string(),
+            last_ms: matmul.mlx().last_ms(),
+            average_ms: matmul.mlx().average_ms(),
+            level: 0,
+        });
+    }
+
     for (idx, stat) in blocks.iter().enumerate() {
         rows.push(LatencyRow {
             label: format!("Block {}", idx + 1),


### PR DESCRIPTION
## Summary
- include MLX matmul latency samples in the dashboard by adding a dedicated row

## Testing
- not run (Metal tooling unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68df402ddaa48326ba6fe7a7f68779bf