### PR TITLE
Prewarm Metal kernels during context initialization

### DIFF
--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -260,6 +260,9 @@ impl<T: TensorElement> Context<T> {
         // Prime the command buffer and resource cache so the very first kernel dispatch
         // can encode immediately after context creation.
         context.ensure_active_cmd_buffer()?;
+        if let Some(cache) = context.active_resource_cache.as_mut() {
+            cache.prewarm_matmul_resources(&context.device)?;
+        }
 
         Ok(context)
     }

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -214,6 +214,9 @@ impl<T: TensorElement> Context<T> {
         let forced_backend = detect_forced_matmul_backend();
         let log_matmul_shapes = env_flag_enabled(env::var(MATMUL_TRACE_ENV));
 
+        let mut kernel_manager = KernelManager::new();
+        kernel_manager.prewarm_all(&device)?;
+
         if log_matmul_shapes {
             let _ = matmul_shape_logger();
         }
@@ -234,7 +237,7 @@ impl<T: TensorElement> Context<T> {
             command_queue,
             pool,
             kv_cache_pool,
-            kernel_manager: KernelManager::new(),
+            kernel_manager,
             pooled_bytes_allocated: 0,
             pooled_allocations: 0,
             pool_resets: 0,

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -232,7 +232,7 @@ impl<T: TensorElement> Context<T> {
             }
         });
 
-        Ok(Context::<T> {
+        let mut context = Context::<T> {
             device,
             command_queue,
             pool,
@@ -255,7 +255,13 @@ impl<T: TensorElement> Context<T> {
             log_matmul_shapes,
             mlx_kernel_cache: MlxKernelCache::default(),
             //config,
-        })
+        };
+
+        // Prime the command buffer and resource cache so the very first kernel dispatch
+        // can encode immediately after context creation.
+        context.ensure_active_cmd_buffer()?;
+
+        Ok(context)
     }
 
     pub fn tensor_dtype(&self) -> Dtype {

--- a/src/metallic/kernels/kernel_manager.rs
+++ b/src/metallic/kernels/kernel_manager.rs
@@ -35,6 +35,25 @@ impl KernelManager {
         Self::default()
     }
 
+    pub fn prewarm_all(&mut self, device: &Retained<ProtocolObject<dyn MTLDevice>>) -> Result<(), MetalError> {
+        for &function in ALL_KERNEL_FUNCTIONS {
+            for &dtype in &[Dtype::F16, Dtype::F32] {
+                let _ = self.get_pipeline(function, dtype, device)?;
+            }
+        }
+
+        #[cfg(test)]
+        {
+            assert_eq!(
+                self.pipelines.len(),
+                ALL_KERNEL_FUNCTIONS.len() * 2,
+                "prewarm must cover every kernel/dtype combination",
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn get_pipeline(
         &mut self,
         func: KernelFunction,

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -109,6 +109,32 @@ pub enum KernelFunction {
     Gemv,
 }
 
+pub(crate) const ALL_KERNEL_FUNCTIONS: &[KernelFunction] = &[
+    KernelFunction::CastToF16,
+    KernelFunction::CastFromF16,
+    KernelFunction::CastToF32,
+    KernelFunction::CastFromF32,
+    KernelFunction::ElemwiseAdd,
+    KernelFunction::ElemwiseBroadcastAdd,
+    KernelFunction::ElemwiseDiv,
+    KernelFunction::ElemwiseMul,
+    KernelFunction::ElemwiseSub,
+    KernelFunction::Gelu,
+    KernelFunction::KvRearrange,
+    KernelFunction::LayerNorm,
+    KernelFunction::Permute,
+    KernelFunction::RepeatKvHeads,
+    KernelFunction::Rope,
+    KernelFunction::RMSNorm,
+    KernelFunction::Silu,
+    KernelFunction::FusedSoftmax,
+    KernelFunction::SwigluFusedActivation,
+    KernelFunction::Arange,
+    KernelFunction::Ones,
+    KernelFunction::RandomUniform,
+    KernelFunction::Gemv,
+];
+
 impl KernelFunction {
     fn library(&self) -> KernelLibrary {
         match self {


### PR DESCRIPTION
## Summary
- add a canonical list of kernel functions so the manager can deterministically prewarm caches
- warm every kernel pipeline for both F16 and F32 dtypes during context creation
- assert under tests that the prewarm path covers every kernel/dtype combination

## Testing
- Not run (Metal/Apple Silicon not available in sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e07e8606b883269a10882ee990ecd6