### PR TITLE
Optimize permute constant uploads

### DIFF
--- a/src/metallic/encoder.rs
+++ b/src/metallic/encoder.rs
@@ -29,7 +29,7 @@ pub fn set_bytes<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder
     // SAFETY: `data` is a valid reference, so its pointer is non-null.
     // Convert the reference into a NonNull<c_void> as required by the objc2 binding.
     unsafe {
-        let ptr = std::ptr::NonNull::from(data).cast::<c_void>();
+        let ptr = std::ptr::NonNull::<T>::from(data).cast::<c_void>();
         encoder.setBytes_length_atIndex(ptr, size, index);
     }
 }
@@ -43,9 +43,9 @@ pub fn set_bytes_slice<T: Sized>(encoder: &ProtocolObject<dyn MTLComputeCommandE
     // `std::ptr::NonNull::dangling` which is valid for zero-length accesses.
     unsafe {
         let ptr = if data.is_empty() {
-            std::ptr::NonNull::dangling().cast::<c_void>()
+            std::ptr::NonNull::<T>::dangling().cast::<c_void>()
         } else {
-            std::ptr::NonNull::new_unchecked(data.as_ptr() as *mut c_void)
+            std::ptr::NonNull::new_unchecked(data.as_ptr() as *mut T).cast::<c_void>()
         };
         encoder.setBytes_length_atIndex(ptr, size, index);
     }

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -123,14 +123,16 @@ fn log_cache_stats<T: TensorElement>(ctx: &Context<T>, phase: &str, step: usize)
 
     let line = match ctx.get_cache_stats() {
         Some(stats) => format!(
-            "[metal-cache] {phase}#{step}: gemm_cache_size={} descriptor_cache_size={} softmax_cache_size={} sdpa_cache_size={} permute_constant_cache_size={} permute_constant_cache_hits={} permute_constant_cache_misses={}",
+            "[metal-cache] {phase}#{step}: gemm_cache_size={} descriptor_cache_size={} softmax_cache_size={} sdpa_cache_size={} permute_constant_cache_size={} permute_constant_cache_hits={} permute_constant_cache_misses={} permute_inline_uploads={} permute_inline_bytes={}",
             stats.gemm_cache_size,
             stats.descriptor_cache_size,
             stats.softmax_cache_size,
             stats.sdpa_cache_size,
             stats.permute_constant_cache_size,
             stats.permute_constant_cache_hits,
-            stats.permute_constant_cache_misses
+            stats.permute_constant_cache_misses,
+            stats.permute_inline_uploads,
+            stats.permute_inline_bytes
         ),
         None => format!("[metal-cache] {phase}#{step}: cache-uninitialized"),
     };

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -123,7 +123,7 @@ fn log_cache_stats<T: TensorElement>(ctx: &Context<T>, phase: &str, step: usize)
 
     let line = match ctx.get_cache_stats() {
         Some(stats) => format!(
-            "[metal-cache] {phase}#{step}: gemm_cache_size={} descriptor_cache_size={} softmax_cache_size={} sdpa_cache_size={} permute_constant_cache_size={} permute_constant_cache_hits={} permute_constant_cache_misses={} permute_inline_uploads={} permute_inline_bytes={}",
+            "[metal-cache] {phase}#{step}: gemm_cache_size={} descriptor_cache_size={} softmax_cache_size={} sdpa_cache_size={} permute_constant_cache_size={} permute_constant_cache_hits={} permute_constant_cache_misses={} permute_inline_uploads={} permute_inline_bytes={} permute_inline_max_bytes={} permute_cached_max_bytes={}",
             stats.gemm_cache_size,
             stats.descriptor_cache_size,
             stats.softmax_cache_size,
@@ -132,7 +132,9 @@ fn log_cache_stats<T: TensorElement>(ctx: &Context<T>, phase: &str, step: usize)
             stats.permute_constant_cache_hits,
             stats.permute_constant_cache_misses,
             stats.permute_inline_uploads,
-            stats.permute_inline_bytes
+            stats.permute_inline_bytes,
+            stats.permute_inline_max_bytes,
+            stats.permute_cached_max_bytes
         ),
         None => format!("[metal-cache] {phase}#{step}: cache-uninitialized"),
     };

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -123,8 +123,14 @@ fn log_cache_stats<T: TensorElement>(ctx: &Context<T>, phase: &str, step: usize)
 
     let line = match ctx.get_cache_stats() {
         Some(stats) => format!(
-            "[metal-cache] {phase}#{step}: gemm_cache_size={} descriptor_cache_size={} softmax_cache_size={} sdpa_cache_size={}",
-            stats.gemm_cache_size, stats.descriptor_cache_size, stats.softmax_cache_size, stats.sdpa_cache_size
+            "[metal-cache] {phase}#{step}: gemm_cache_size={} descriptor_cache_size={} softmax_cache_size={} sdpa_cache_size={} permute_constant_cache_size={} permute_constant_cache_hits={} permute_constant_cache_misses={}",
+            stats.gemm_cache_size,
+            stats.descriptor_cache_size,
+            stats.softmax_cache_size,
+            stats.sdpa_cache_size,
+            stats.permute_constant_cache_size,
+            stats.permute_constant_cache_hits,
+            stats.permute_constant_cache_misses
         ),
         None => format!("[metal-cache] {phase}#{step}: cache-uninitialized"),
     };

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -1,6 +1,6 @@
 use crate::metallic::{
     Context, Dtype, MetalError, Operation, Tensor,
-    encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_compute_pipeline_state},
+    encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_bytes_slice, set_compute_pipeline_state},
     resource_cache::ResourceCache,
 };
 use objc2::rc::Retained;

--- a/src/metallic/kernels/permute/mod.rs
+++ b/src/metallic/kernels/permute/mod.rs
@@ -106,8 +106,11 @@ impl<T: TensorElement> Operation for Permute<T> {
                 Ok(())
             } else {
                 let buffer = cache.get_or_create_permute_constant_buffer(device, kind, length)?;
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr() as *const u8, buffer.contents() as *mut u8, length);
+                if length > 0 {
+                    unsafe {
+                        let dst = buffer.contents().as_ptr().cast::<u8>();
+                        std::ptr::copy_nonoverlapping(data.as_ptr().cast::<u8>(), dst, length);
+                    }
                 }
                 set_buffer(&encoder, index, &buffer, 0);
                 retained_buffers.push(buffer);

--- a/src/metallic/tests/mod.rs
+++ b/src/metallic/tests/mod.rs
@@ -13,5 +13,6 @@ mod error_path_test;
 mod forward_pass_correctness_test;
 mod generation_test;
 mod matmul;
+mod permute_cache_test;
 mod resource_cache_persistence_test;
 mod tensor_test;

--- a/src/metallic/tests/permute_cache_test.rs
+++ b/src/metallic/tests/permute_cache_test.rs
@@ -1,0 +1,42 @@
+use crate::metallic::{Context, F32Element, MetalError, Tensor, TensorInit, TensorStorage};
+
+fn build_high_rank_tensor(ctx: &Context<F32Element>, rank: usize) -> Result<Tensor<F32Element>, MetalError> {
+    let dims = vec![1usize; rank];
+    // Only a single element is required because each dimension is size one.
+    let data = [0.0f32];
+    Tensor::new(dims, TensorStorage::Dedicated(ctx), TensorInit::CopyFrom(&data))
+}
+
+#[test]
+fn permute_large_rank_reuses_constant_buffers() -> Result<(), MetalError> {
+    let mut ctx = Context::<F32Element>::new()?;
+    let rank = 1025; // Ensure the constant payload exceeds Metal's 4KB inline threshold.
+    let tensor = build_high_rank_tensor(&ctx, rank)?;
+    let permutation: Vec<usize> = (0..rank).rev().collect();
+
+    // First dispatch populates the cache via misses.
+    let _ = tensor.permute(&permutation, &mut ctx)?;
+    let stats_after_first = ctx
+        .get_cache_stats()
+        .expect("resource cache should be initialized after first permute");
+    assert_eq!(stats_after_first.permute_constant_cache_size, 4);
+    assert_eq!(stats_after_first.permute_constant_cache_hits, 0);
+    assert_eq!(stats_after_first.permute_constant_cache_misses, 4);
+
+    // Subsequent dispatches should reuse the cached buffers.
+    for _ in 0..3 {
+        let _ = tensor.permute(&permutation, &mut ctx)?;
+    }
+
+    let stats_after_reuse = ctx
+        .get_cache_stats()
+        .expect("resource cache should remain available for subsequent permutes");
+    assert_eq!(stats_after_reuse.permute_constant_cache_size, 4);
+    assert_eq!(stats_after_reuse.permute_constant_cache_misses, 4);
+    assert!(
+        stats_after_reuse.permute_constant_cache_hits >= 12,
+        "expected at least three cache hits per constant buffer after reuse"
+    );
+
+    Ok(())
+}

--- a/src/metallic/tests/resource_cache_persistence_test.rs
+++ b/src/metallic/tests/resource_cache_persistence_test.rs
@@ -43,6 +43,18 @@ fn resource_cache_survives_synchronize() -> Result<(), MetalError> {
         stats_before.sdpa_cache_size, stats_after.sdpa_cache_size,
         "SDPA cache entries should survive a command buffer flush",
     );
+    assert_eq!(
+        stats_before.permute_constant_cache_size, stats_after.permute_constant_cache_size,
+        "Permute constant cache entries should survive a command buffer flush",
+    );
+    assert_eq!(
+        stats_before.permute_constant_cache_hits, stats_after.permute_constant_cache_hits,
+        "Permute constant cache hits should survive a command buffer flush",
+    );
+    assert_eq!(
+        stats_before.permute_constant_cache_misses, stats_after.permute_constant_cache_misses,
+        "Permute constant cache misses should survive a command buffer flush",
+    );
 
     Ok(())
 }

--- a/src/metallic/tests/resource_cache_persistence_test.rs
+++ b/src/metallic/tests/resource_cache_persistence_test.rs
@@ -63,6 +63,14 @@ fn resource_cache_survives_synchronize() -> Result<(), MetalError> {
         stats_before.permute_inline_bytes, stats_after.permute_inline_bytes,
         "Permute inline byte counter should survive a command buffer flush",
     );
+    assert_eq!(
+        stats_before.permute_inline_max_bytes, stats_after.permute_inline_max_bytes,
+        "Permute inline max byte counter should survive a command buffer flush",
+    );
+    assert_eq!(
+        stats_before.permute_cached_max_bytes, stats_after.permute_cached_max_bytes,
+        "Permute cached max byte counter should survive a command buffer flush",
+    );
 
     Ok(())
 }

--- a/src/metallic/tests/resource_cache_persistence_test.rs
+++ b/src/metallic/tests/resource_cache_persistence_test.rs
@@ -55,6 +55,14 @@ fn resource_cache_survives_synchronize() -> Result<(), MetalError> {
         stats_before.permute_constant_cache_misses, stats_after.permute_constant_cache_misses,
         "Permute constant cache misses should survive a command buffer flush",
     );
+    assert_eq!(
+        stats_before.permute_inline_uploads, stats_after.permute_inline_uploads,
+        "Permute inline upload count should survive a command buffer flush",
+    );
+    assert_eq!(
+        stats_before.permute_inline_bytes, stats_after.permute_inline_bytes,
+        "Permute inline byte counter should survive a command buffer flush",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- bind permute constants with inline `set_bytes` when under the 4KB Metal limit
- extend the resource cache to reuse large permute constant buffers and track their stats
- add a regression test that stresses repeated high-rank permutes and verifies cache reuse metrics

## Testing
- Not run (Metal/objc2 tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e13c65d9b08326879b20edffbc56e2