### PR TITLE
Add Metal KV cache write kernel and instrumentation

### DIFF
--- a/src/metallic/kernels/kv_cache_write/kernel.metal
+++ b/src/metallic/kernels/kv_cache_write/kernel.metal
@@ -1,0 +1,56 @@
+#include <metal_stdlib>
+using namespace metal;
+
+#define FOR_EACH_FLOAT_TYPE(OP) \
+    OP(float, f32) \
+    OP(half, f16)
+
+#define DEFINE_KV_CACHE_WRITE_KERNEL(SCALAR, SUFFIX) \
+kernel void kv_cache_write_kernel_##SUFFIX( \
+    device const SCALAR* k_src [[buffer(0)]], \
+    device const SCALAR* v_src [[buffer(1)]], \
+    device SCALAR* k_dst [[buffer(2)]], \
+    device SCALAR* v_dst [[buffer(3)]], \
+    constant uint& canonical_heads [[buffer(4)]], \
+    constant uint& head_dim [[buffer(5)]], \
+    constant uint& seq_len [[buffer(6)]], \
+    constant uint& step [[buffer(7)]], \
+    constant uint& group_size [[buffer(8)]], \
+    constant uint& src_head_stride [[buffer(9)]], \
+    constant uint& src_seq_stride [[buffer(10)]], \
+    constant uint& dst_head_stride [[buffer(11)]], \
+    constant uint& dst_seq_stride [[buffer(12)]], \
+    constant uint& k_src_offset [[buffer(13)]], \
+    constant uint& v_src_offset [[buffer(14)]], \
+    constant uint& k_dst_offset [[buffer(15)]], \
+    constant uint& v_dst_offset [[buffer(16)]], \
+    constant uint& total_threads [[buffer(17)]], \
+    uint gid [[thread_position_in_grid]]) { \
+    if (gid >= total_threads) { \
+        return; \
+    } \
+    uint head_idx = gid / head_dim; \
+    if (head_idx >= canonical_heads) { \
+        return; \
+    } \
+    uint dim_idx = gid % head_dim; \
+    for (uint seq_idx = 0; seq_idx < seq_len; ++seq_idx) { \
+        uint k_src_index = k_src_offset + head_idx * src_head_stride + seq_idx * src_seq_stride + dim_idx; \
+        uint v_src_index = v_src_offset + head_idx * src_head_stride + seq_idx * src_seq_stride + dim_idx; \
+        SCALAR k_value = k_src[k_src_index]; \
+        SCALAR v_value = v_src[v_src_index]; \
+        uint cache_step = step + seq_idx; \
+        for (uint group = 0; group < group_size; ++group) { \
+            uint dst_head = head_idx * group_size + group; \
+            uint k_dst_index = k_dst_offset + dst_head * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
+            uint v_dst_index = v_dst_offset + dst_head * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
+            k_dst[k_dst_index] = k_value; \
+            v_dst[v_dst_index] = v_value; \
+        } \
+    } \
+}
+
+FOR_EACH_FLOAT_TYPE(DEFINE_KV_CACHE_WRITE_KERNEL)
+
+#undef DEFINE_KV_CACHE_WRITE_KERNEL
+#undef FOR_EACH_FLOAT_TYPE

--- a/src/metallic/kernels/kv_cache_write/mod.rs
+++ b/src/metallic/kernels/kv_cache_write/mod.rs
@@ -1,0 +1,130 @@
+use super::*;
+use crate::metallic::TensorElement;
+
+pub struct KvCacheWriteOp;
+
+#[derive(Clone, Debug)]
+pub struct KvCacheWriteConfig {
+    pub canonical_heads: u32,
+    pub head_dim: u32,
+    pub seq_len: u32,
+    pub step: u32,
+    pub group_size: u32,
+    pub src_head_stride: u32,
+    pub src_seq_stride: u32,
+    pub dst_head_stride: u32,
+    pub dst_seq_stride: u32,
+    pub k_src_offset: u32,
+    pub v_src_offset: u32,
+    pub k_dst_offset: u32,
+    pub v_dst_offset: u32,
+    pub total_threads: u32,
+}
+
+struct KvCacheWrite<T: TensorElement> {
+    k_src: Tensor<T>,
+    v_src: Tensor<T>,
+    k_dst: Tensor<T>,
+    v_dst: Tensor<T>,
+    params: KvCacheWriteConfig,
+    pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+}
+
+impl KernelInvocable for KvCacheWriteOp {
+    type Args<'a, T: TensorElement> = (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>, KvCacheWriteConfig);
+
+    fn function_id() -> Option<KernelFunction> {
+        Some(KernelFunction::KvCacheWrite)
+    }
+
+    fn new<'a, T: TensorElement>(
+        ctx: &mut Context<T>,
+        args: Self::Args<'a, T>,
+        pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
+        _cache: Option<&mut ResourceCache>,
+    ) -> Result<(Box<dyn Operation>, Tensor<T>), MetalError> {
+        let (k_src, v_src, k_dst, v_dst, params) = args;
+
+        if params.canonical_heads == 0 {
+            return Err(MetalError::InvalidShape(
+                "kv_cache_write requires a positive head count".to_string(),
+            ));
+        }
+        if params.head_dim == 0 {
+            return Err(MetalError::InvalidShape(
+                "kv_cache_write requires a positive head dimension".to_string(),
+            ));
+        }
+        if params.seq_len == 0 {
+            return Err(MetalError::InvalidShape(
+                "kv_cache_write expects at least one active sequence element".to_string(),
+            ));
+        }
+        if params.group_size == 0 {
+            return Err(MetalError::InvalidShape(
+                "kv_cache_write requires a non-zero group size".to_string(),
+            ));
+        }
+
+        ctx.prepare_tensors_for_active_cmd(&[&k_src, &v_src, &k_dst, &v_dst])?;
+
+        let pipeline = pipeline.expect("Kernel Library supplied for MetalKernels");
+        let op = KvCacheWrite {
+            k_src: k_src.clone(),
+            v_src,
+            k_dst: k_dst.clone(),
+            v_dst,
+            params,
+            pipeline,
+        };
+
+        Ok((Box::new(op), k_dst))
+    }
+}
+
+impl<T: TensorElement> Operation for KvCacheWrite<T> {
+    fn encode(
+        &self,
+        command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+        _cache: &mut ResourceCache,
+    ) -> Result<(), MetalError> {
+        let encoder = command_buffer
+            .computeCommandEncoder()
+            .ok_or(MetalError::ComputeEncoderCreationFailed)?;
+
+        let threads_per_tg = MTLSize {
+            width: 256,
+            height: 1,
+            depth: 1,
+        };
+        let groups = MTLSize {
+            width: self.params.total_threads.div_ceil(256) as usize,
+            height: 1,
+            depth: 1,
+        };
+
+        set_compute_pipeline_state(&encoder, &self.pipeline);
+        set_buffer(&encoder, 0, &self.k_src.buf, self.k_src.offset);
+        set_buffer(&encoder, 1, &self.v_src.buf, self.v_src.offset);
+        set_buffer(&encoder, 2, &self.k_dst.buf, self.k_dst.offset);
+        set_buffer(&encoder, 3, &self.v_dst.buf, self.v_dst.offset);
+        set_bytes(&encoder, 4, &self.params.canonical_heads);
+        set_bytes(&encoder, 5, &self.params.head_dim);
+        set_bytes(&encoder, 6, &self.params.seq_len);
+        set_bytes(&encoder, 7, &self.params.step);
+        set_bytes(&encoder, 8, &self.params.group_size);
+        set_bytes(&encoder, 9, &self.params.src_head_stride);
+        set_bytes(&encoder, 10, &self.params.src_seq_stride);
+        set_bytes(&encoder, 11, &self.params.dst_head_stride);
+        set_bytes(&encoder, 12, &self.params.dst_seq_stride);
+        set_bytes(&encoder, 13, &self.params.k_src_offset);
+        set_bytes(&encoder, 14, &self.params.v_src_offset);
+        set_bytes(&encoder, 15, &self.params.k_dst_offset);
+        set_bytes(&encoder, 16, &self.params.v_dst_offset);
+        set_bytes(&encoder, 17, &self.params.total_threads);
+
+        dispatch_threadgroups(&encoder, groups, threads_per_tg);
+        encoder.endEncoding();
+        Ok(())
+    }
+}

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -21,6 +21,7 @@ pub mod elemwise_mul;
 pub mod elemwise_sub;
 pub mod gelu;
 pub mod gemv;
+pub mod kv_cache_write;
 pub mod kv_rearrange;
 pub mod layernorm;
 pub mod matmul;
@@ -44,6 +45,7 @@ pub enum KernelLibrary {
     ElemwiseMul,
     ElemwiseSub,
     Gelu,
+    KvCacheWrite,
     KvRearrange,
     LayerNorm,
     Permute,
@@ -66,6 +68,7 @@ impl KernelLibrary {
             KernelLibrary::ElemwiseMul => include_str!("elemwise_mul/kernel.metal"),
             KernelLibrary::ElemwiseSub => include_str!("elemwise_sub/kernel.metal"),
             KernelLibrary::Gelu => include_str!("gelu/kernel.metal"),
+            KernelLibrary::KvCacheWrite => include_str!("kv_cache_write/kernel.metal"),
             KernelLibrary::KvRearrange => include_str!("kv_rearrange/kernel.metal"),
             KernelLibrary::LayerNorm => include_str!("layernorm/kernel.metal"),
             KernelLibrary::Permute => include_str!("permute/kernel.metal"),
@@ -94,6 +97,7 @@ pub enum KernelFunction {
     ElemwiseMul,
     ElemwiseSub,
     Gelu,
+    KvCacheWrite,
     KvRearrange,
     LayerNorm,
     Permute,
@@ -120,6 +124,7 @@ impl KernelFunction {
             KernelFunction::ElemwiseMul => KernelLibrary::ElemwiseMul,
             KernelFunction::ElemwiseSub => KernelLibrary::ElemwiseSub,
             KernelFunction::Gelu => KernelLibrary::Gelu,
+            KernelFunction::KvCacheWrite => KernelLibrary::KvCacheWrite,
             KernelFunction::KvRearrange => KernelLibrary::KvRearrange,
             KernelFunction::LayerNorm => KernelLibrary::LayerNorm,
             KernelFunction::Permute => KernelLibrary::Permute,
@@ -158,6 +163,8 @@ impl KernelFunction {
             (KernelFunction::ElemwiseSub, F16) => "sub_kernel_f16",
             (KernelFunction::Gelu, F32) => "gelu_kernel_f32",
             (KernelFunction::Gelu, F16) => "gelu_kernel_f16",
+            (KernelFunction::KvCacheWrite, F32) => "kv_cache_write_kernel_f32",
+            (KernelFunction::KvCacheWrite, F16) => "kv_cache_write_kernel_f16",
             (KernelFunction::KvRearrange, F32) => "kv_rearrange_kernel_f32",
             (KernelFunction::KvRearrange, F16) => "kv_rearrange_kernel_f16",
             (KernelFunction::LayerNorm, F32) => "layernorm_kernel_f32",

--- a/src/metallic/tests/forward_pass_correctness_test.rs
+++ b/src/metallic/tests/forward_pass_correctness_test.rs
@@ -1687,6 +1687,127 @@ fn test_forward_step_kv_cache_matches_pytorch_logits() -> Result<(), crate::meta
     Ok(())
 }
 
+#[test]
+fn test_kv_cache_write_kernel_updates_cache_and_records_dispatches() -> Result<(), crate::metallic::MetalError> {
+    use crate::metallic::{F32Element, TensorInit, TensorStorage};
+
+    let mut ctx = Context::<F32Element>::new()?;
+    let layer_idx = 0usize;
+    let batch = 1usize;
+    let n_kv_heads = 2usize;
+    let group_size = 3usize;
+    let n_heads = n_kv_heads * group_size;
+    let head_dim = 4usize;
+    let cache_capacity = 5usize;
+
+    ctx.alloc_kv_cache(layer_idx, cache_capacity, batch * n_kv_heads, batch * n_heads, head_dim)?;
+
+    let mut k_values = Vec::with_capacity(batch * n_kv_heads * head_dim);
+    let mut v_values = Vec::with_capacity(batch * n_kv_heads * head_dim);
+    for bh in 0..(batch * n_kv_heads) {
+        for d in 0..head_dim {
+            k_values.push((bh * head_dim + d) as f32 + 0.25);
+            v_values.push((bh * head_dim + d) as f32 + 0.75);
+        }
+    }
+
+    let k_step = Tensor::new(
+        vec![batch * n_kv_heads, 1, head_dim],
+        TensorStorage::Dedicated(&ctx),
+        TensorInit::CopyFrom(&k_values),
+    )?;
+    let v_step = Tensor::new(
+        vec![batch * n_kv_heads, 1, head_dim],
+        TensorStorage::Dedicated(&ctx),
+        TensorInit::CopyFrom(&v_values),
+    )?;
+
+    ctx.reset_kv_cache_dispatch_stats();
+    ctx.write_kv_step(layer_idx, 0, &k_step, &v_step)?;
+    ctx.synchronize();
+
+    let stats = ctx.kv_cache_dispatch_stats();
+    assert_eq!(stats.canonical_dispatches, 1);
+    assert_eq!(stats.canonical_fallback_blits, 0);
+
+    let entry = ctx
+        .kv_caches
+        .get(&layer_idx)
+        .cloned()
+        .expect("kv cache must exist after allocation");
+    let k_cache_slice = entry.k.as_slice();
+    let v_cache_slice = entry.v.as_slice();
+
+    for bh in 0..(batch * n_kv_heads) {
+        for d in 0..head_dim {
+            let expected_k = k_values[bh * head_dim + d];
+            let expected_v = v_values[bh * head_dim + d];
+            let index = (bh * cache_capacity + 0) * head_dim + d;
+            assert!(
+                (k_cache_slice[index] - expected_k).abs() < 1e-6,
+                "canonical K mismatch at head {} dim {}: {} vs {}",
+                bh,
+                d,
+                k_cache_slice[index],
+                expected_k
+            );
+            assert!(
+                (v_cache_slice[index] - expected_v).abs() < 1e-6,
+                "canonical V mismatch at head {} dim {}: {} vs {}",
+                bh,
+                d,
+                v_cache_slice[index],
+                expected_v
+            );
+        }
+    }
+
+    ctx.reset_kv_cache_dispatch_stats();
+    ctx.write_repeated_kv_step(layer_idx, 0, group_size, &k_step, &v_step)?;
+    ctx.synchronize();
+
+    let stats = ctx.kv_cache_dispatch_stats();
+    assert_eq!(stats.repeated_dispatches, 1);
+    assert_eq!(stats.repeated_fallback_blits, 0);
+
+    let entry = ctx
+        .kv_caches
+        .get(&layer_idx)
+        .cloned()
+        .expect("kv cache must exist after allocation");
+    let repeated_k_slice = entry.repeated_k.as_slice();
+    let repeated_v_slice = entry.repeated_v.as_slice();
+
+    for kv_head in 0..(batch * n_kv_heads) {
+        for group in 0..group_size {
+            let repeated_head = kv_head * group_size + group;
+            for d in 0..head_dim {
+                let expected_k = k_values[kv_head * head_dim + d];
+                let expected_v = v_values[kv_head * head_dim + d];
+                let index = (repeated_head * cache_capacity + 0) * head_dim + d;
+                assert!(
+                    (repeated_k_slice[index] - expected_k).abs() < 1e-6,
+                    "repeated K mismatch at head {} dim {}: {} vs {}",
+                    repeated_head,
+                    d,
+                    repeated_k_slice[index],
+                    expected_k
+                );
+                assert!(
+                    (repeated_v_slice[index] - expected_v).abs() < 1e-6,
+                    "repeated V mismatch at head {} dim {}: {} vs {}",
+                    repeated_head,
+                    d,
+                    repeated_v_slice[index],
+                    expected_v
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn dump_kv_snapshot<T: TensorElement>(ctx: &mut Context<T>, step: usize) {
     ctx.synchronize();
 


### PR DESCRIPTION
## Summary
- add a kv_cache_write compute kernel that populates canonical and repeated KV caches in a single dispatch
- rework Context::write_kv_step and write_repeated_kv_step to use the new kernel with explicit metadata and instrumentation-backed fallbacks
- extend the forward pass correctness suite with coverage that validates cache contents and dispatch counters

## Testing
- not run (Metal-dependent tests require Apple Silicon environment)

------
https://chatgpt.com/codex/tasks/task_e_68e14b5b8cd883268f5914f20133a5b4