### PR TITLE
Refine matmul instrumentation with per-dispatch GPU timing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ bench = false
 [dependencies]
 burn = { version = "0.18.0", features = ["webgpu", "fusion", "metal"] }
 objc2 = "0.6.2"
-objc2-foundation = "0.3.1"
-objc2-metal = { version = "0.3.1", features = ["block2", "MTLArgument", "MTLFunctionConstantValues"] }
+objc2-foundation = { version = "0.3.1", features = ["NSData"] }
+objc2-metal = { version = "0.3.1", features = ["block2", "MTLArgument", "MTLFunctionConstantValues", "MTLCounters"] }
 objc2-metal-performance-shaders = "0.3.1"
 block2 = "0.6.1"
 rand = "0.9.2"
@@ -35,6 +35,7 @@ sysinfo = "0.37.1"
 chrono = { version = "0.4", features = ["clock", "serde"] }
 half = { version = "2.6.0", features = ["zerocopy", "bytemuck", "num-traits", "use-intrinsics"] }
 num-traits = "0.2.19"
+libc = { version = "0.2", optional = false }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -1,6 +1,8 @@
 use super::error::MetalError;
 use super::instrumentation::{
-    LatencyCollectorHandle, LatencyEvent, MatMulInstrumentation, MatMulSampleRecorder, MemoryCollectorHandle, MemoryEvent, MemoryUsage,
+    LatencyCollectorHandle, LatencyEvent, MatMulDispatchHandle, MatMulDispatchKind, MatMulDispatchRegistration,
+    MatMulInstrumentation, MatMulSampleRecorder, MatmulDims,
+    MemoryCollectorHandle, MemoryEvent, MemoryUsage,
 };
 use super::operation::CommandBuffer;
 use super::pool::MemoryPool;
@@ -22,6 +24,7 @@ use objc2_metal::MTLCommandBuffer;
 use objc2_metal::MTLCommandEncoder as _;
 use objc2_metal::{MTLCommandQueue, MTLCreateSystemDefaultDevice, MTLDevice};
 use rustc_hash::FxHashMap;
+use std::cell::RefCell;
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -164,14 +167,6 @@ struct RepeatedWritePlan<T: TensorElement> {
     dst_seq_stride: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
-struct MatmulDims {
-    batch: usize,
-    m: usize,
-    n: usize,
-    k: usize,
-}
-
 struct MatmulShapeLogger {
     file: Mutex<std::fs::File>,
 }
@@ -214,6 +209,7 @@ pub struct Context<T: TensorElement> {
     /// Matmul timing samples captured since the last drain.
     matmul_samples: Arc<Mutex<Vec<MatMulSample>>>,
     matmul_recorder: MatMulSampleRecorder,
+    matmul_logging_session: RefCell<Option<Vec<MatMulDispatchHandle>>>,
     /// Workspace reused across sampling invocations to avoid per-token allocations.
     pub sampler_buffers: SamplerBuffers,
     /// Optional override for the matmul backend chosen by this context.
@@ -272,12 +268,12 @@ impl<T: TensorElement> Context<T> {
 
         let matmul_samples = Arc::new(Mutex::new(Vec::new()));
         let samples_for_recorder = Arc::clone(&matmul_samples);
-        let matmul_recorder = MatMulSampleRecorder::new(move |backend, duration| {
-            if duration.is_zero() {
+        let matmul_recorder = MatMulSampleRecorder::new(move |sample| {
+            if sample.duration.is_zero() {
                 return;
             }
             if let Ok(mut samples) = samples_for_recorder.lock() {
-                samples.push(MatMulSample { backend, duration });
+                samples.push(sample);
             }
         });
 
@@ -296,9 +292,10 @@ impl<T: TensorElement> Context<T> {
             active_resource_cache: None,
             latency_collector: None,
             memory_collector: None,
-            matmul_instrumentation: MatMulInstrumentation::default(),
+            matmul_instrumentation: MatMulInstrumentation::new(Some(&device)),
             matmul_samples,
             matmul_recorder,
+            matmul_logging_session: RefCell::new(None),
             sampler_buffers: SamplerBuffers::default(),
             forced_matmul_backend: forced_backend,
             log_matmul_shapes,
@@ -361,14 +358,51 @@ impl<T: TensorElement> Context<T> {
         }
     }
 
-    pub(crate) fn register_matmul_dispatch(&self, command_buffer: &CommandBuffer, backend: MatMulBackend) {
-        self.matmul_instrumentation
-            .register(command_buffer, backend, self.matmul_recorder.clone());
+    pub(crate) fn register_matmul_dispatch(
+        &self,
+        command_buffer: &CommandBuffer,
+        backend: MatMulBackend,
+        dims: Option<MatmulDims>,
+        kind: MatMulDispatchKind,
+    ) -> MatMulDispatchRegistration {
+        let registration = self.matmul_instrumentation.register(
+            command_buffer,
+            backend,
+            dims,
+            kind,
+            self.matmul_recorder.clone(),
+        );
+        self.track_matmul_dispatch(registration.handle());
+        registration
+    }
+
+    fn track_matmul_dispatch(&self, handle: MatMulDispatchHandle) {
+        let mut guard = self.matmul_logging_session.borrow_mut();
+        if let Some(session) = guard.as_mut() {
+            session.push(handle);
+        }
+    }
+
+    fn begin_matmul_logging_session(&self) {
+        *self.matmul_logging_session.borrow_mut() = Some(Vec::new());
+    }
+
+    fn finish_matmul_logging_session(&self) -> Vec<MatMulDispatchHandle> {
+        self
+            .matmul_logging_session
+            .borrow_mut()
+            .take()
+            .unwrap_or_default()
     }
 
     #[allow(dead_code)]
     pub(crate) fn record_matmul_backend_sample(&self, backend: MatMulBackend, duration: Duration) {
-        self.matmul_recorder.record_matmul_backend_sample(backend, duration);
+        self.matmul_recorder.record(MatMulSample {
+            backend,
+            duration,
+            dims: None,
+            handle: None,
+        });
     }
 
     pub fn take_matmul_samples(&self) -> Vec<MatMulSample> {
@@ -377,6 +411,31 @@ impl<T: TensorElement> Context<T> {
             Err(err) => err.into_inner(),
         };
         samples.drain(..).collect()
+    }
+
+    fn matched_matmul_samples(
+        &self,
+        handles: &[MatMulDispatchHandle],
+    ) -> Vec<MatMulSample> {
+        if handles.is_empty() {
+            return Vec::new();
+        }
+
+        let guard = match self.matmul_samples.lock() {
+            Ok(guard) => guard,
+            Err(err) => err.into_inner(),
+        };
+
+        let mut matches = Vec::new();
+        for sample in guard.iter() {
+            if let Some(handle) = sample.handle {
+                if handles.contains(&handle) {
+                    matches.push(*sample);
+                }
+            }
+        }
+
+        matches
     }
 
     pub fn kv_cache_dispatch_stats(&self) -> KvCacheDispatchStats {
@@ -543,20 +602,15 @@ impl<T: TensorElement> Context<T> {
         F: FnOnce(&mut Self) -> Result<Tensor<T>, MetalError>,
     {
         if self.log_matmul_shapes {
-            // Drop any lingering samples from previous dispatches so we only record
-            // timings for this invocation when the command buffer completes.
-            let _ = self.take_matmul_samples();
+            self.begin_matmul_logging_session();
 
             let start = Instant::now();
             let result = f(self);
             let elapsed = start.elapsed();
 
+            let handles = self.finish_matmul_logging_session();
             let gpu_duration = if result.is_ok() {
-                // Ensure the encoded work is flushed so the instrumentation callback fires
-                // and the timing samples become available.
-                self.synchronize();
-
-                let samples = self.take_matmul_samples();
+                let samples = self.matched_matmul_samples(&handles);
                 let total: Duration = samples
                     .iter()
                     .filter(|sample| sample.backend == backend)
@@ -566,10 +620,6 @@ impl<T: TensorElement> Context<T> {
             } else {
                 None
             };
-
-            // Re-establish an active command buffer/resource cache for subsequent calls since
-            // `synchronize` clears them.
-            self.ensure_active_cmd_buffer()?;
 
             self.log_matmul_event(op, backend, dims.as_ref(), elapsed, note, gpu_duration);
             result

--- a/src/metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -2,11 +2,12 @@ use super::*;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;
-use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
+use objc2_metal::{MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrixDescriptor, MPSMatrixMultiplication};
 
 use super::{KernelFunction, KernelInvocable, MatMulBackend};
 use crate::metallic::{
+    instrumentation::{MatMulDispatchKind, MatMulDispatchTiming, MatmulDims},
     Context, MetalError, Operation, Tensor, TensorElement,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
@@ -28,6 +29,7 @@ struct MatMulAlphaBeta {
     pub result_desc: Retained<MPSMatrixDescriptor>,
     pub gemm: Retained<MPSMatrixMultiplication>,
     pub batch_size: usize,
+    pub dispatch_timing: Option<MatMulDispatchTiming>,
 }
 
 // Implement `KernelInvocable` for the public struct.
@@ -155,6 +157,28 @@ impl KernelInvocable for MatMulAlphaBetaOp {
         };
         let result_desc = cache.get_or_create_descriptor(result_desc_key, &ctx.device)?;
 
+        let dims = MatmulDims {
+            batch: matmul_result_view.batch,
+            m: eff_left_rows,
+            n: eff_right_cols,
+            k: eff_left_cols,
+        };
+
+        let dispatch_timing = {
+            let command_buffer = {
+                let command_buffer = ctx.active_command_buffer_mut_without_cache()?;
+                command_buffer.clone()
+            };
+            ctx.register_matmul_dispatch(
+                &command_buffer,
+                MatMulBackend::Mps,
+                Some(dims),
+                MatMulDispatchKind::Blit,
+            )
+            .timing()
+            .cloned()
+        };
+
         // Create the internal operation struct.
         let op = MatMulAlphaBeta {
             left_buf: matmul_left_buf,
@@ -168,15 +192,8 @@ impl KernelInvocable for MatMulAlphaBetaOp {
             result_desc,
             gemm,
             batch_size: matmul_result_view.batch,
+            dispatch_timing,
         };
-
-        {
-            let command_buffer = {
-                let command_buffer = ctx.active_command_buffer_mut_without_cache()?;
-                command_buffer.clone()
-            };
-            ctx.register_matmul_dispatch(&command_buffer, MatMulBackend::Mps);
-        }
 
         // Return the boxed operation and the result tensor (already provided)
         Ok((Box::new(op), result.clone()))
@@ -196,12 +213,43 @@ impl Operation for MatMulAlphaBeta {
         let right = mps_matrix_from_buffer(&self.right_buf, self.right_offset, &self.right_desc);
         let result = mps_matrix_from_buffer(&self.result_buf, self.result_offset, &self.result_desc);
 
+        if let Some(timing) = &self.dispatch_timing {
+            if matches!(timing.kind(), MatMulDispatchKind::Blit) {
+                if let Some(encoder) = command_buffer.blitCommandEncoder() {
+                    unsafe {
+                        encoder.sampleCountersInBuffer_atSampleIndex_withBarrier(
+                            timing.sample_buffer(),
+                            timing.start_index(),
+                            true,
+                        );
+                    }
+                    encoder.endEncoding();
+                }
+            }
+        }
+
         // Encode the MPS matrix multiplication
         unsafe {
             self.gemm.setBatchStart(0 as NSUInteger);
             self.gemm.setBatchSize(self.batch_size as NSUInteger);
         }
         encode_mps_matrix_multiplication(&self.gemm, command_buffer, &left, &right, &result);
+
+        if let Some(timing) = &self.dispatch_timing {
+            if matches!(timing.kind(), MatMulDispatchKind::Blit) {
+                if let Some(encoder) = command_buffer.blitCommandEncoder() {
+                    unsafe {
+                        encoder.sampleCountersInBuffer_atSampleIndex_withBarrier(
+                            timing.sample_buffer(),
+                            timing.end_index(),
+                            false,
+                        );
+                    }
+                    encoder.endEncoding();
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -2,12 +2,13 @@ use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSUInteger;
-use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
+use objc2_metal::{MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLComputePipelineState};
 use objc2_metal_performance_shaders::{MPSMatrix, MPSMatrixDescriptor, MPSMatrixMultiplication};
 use std::time::Duration;
 
 use super::{KernelFunction, KernelInvocable};
 use crate::metallic::{
+    instrumentation::{MatMulDispatchKind, MatMulDispatchTiming, MatmulDims},
     Context, MetalError, Operation, Tensor, TensorElement, TensorInit, TensorStorage,
     cache_keys::{MpsGemmKey, MpsMatrixDescriptorKey},
     resource_cache::ResourceCache,
@@ -35,6 +36,8 @@ pub enum MatMulBackend {
 pub struct MatMulSample {
     pub backend: MatMulBackend,
     pub duration: Duration,
+    pub dims: Option<MatmulDims>,
+    pub handle: Option<MatMulDispatchHandle>,
 }
 
 // Public, user-facing, zero-sized struct for the matmul operation with transpose options.
@@ -53,6 +56,7 @@ struct MatMul {
     pub result_desc: Retained<MPSMatrixDescriptor>,
     pub gemm: Retained<MPSMatrixMultiplication>,
     pub batch_size: usize,
+    pub dispatch_timing: Option<MatMulDispatchTiming>,
 }
 
 // Implement `KernelInvocable` for the public struct.
@@ -183,6 +187,28 @@ impl KernelInvocable for MatMulOp {
         let result_desc = cache.get_or_create_descriptor(result_desc_key, &ctx.device)?;
 
         // Create the internal operation struct.
+        let dims = MatmulDims {
+            batch: matmul_result_view.batch,
+            m: eff_left_rows,
+            n: eff_right_cols,
+            k: eff_left_cols,
+        };
+
+        let dispatch_timing = {
+            let command_buffer = {
+                let command_buffer = ctx.active_command_buffer_mut_without_cache()?;
+                command_buffer.clone()
+            };
+            ctx.register_matmul_dispatch(
+                &command_buffer,
+                MatMulBackend::Mps,
+                Some(dims),
+                MatMulDispatchKind::Blit,
+            )
+            .timing()
+            .cloned()
+        };
+
         let op = MatMul {
             left_buf: matmul_left_buf,
             left_offset: matmul_left_offset,
@@ -195,15 +221,8 @@ impl KernelInvocable for MatMulOp {
             result_desc,
             gemm,
             batch_size: matmul_result_view.batch,
+            dispatch_timing,
         };
-
-        {
-            let command_buffer = {
-                let command_buffer = ctx.active_command_buffer_mut_without_cache()?;
-                command_buffer.clone()
-            };
-            ctx.register_matmul_dispatch(&command_buffer, MatMulBackend::Mps);
-        }
 
         // Return the boxed operation and the output tensor.
         Ok((Box::new(op), out))
@@ -223,12 +242,42 @@ impl Operation for MatMul {
         let right = mps_matrix_from_buffer(&self.right_buf, self.right_offset, &self.right_desc);
         let result = mps_matrix_from_buffer(&self.result_buf, self.result_offset, &self.result_desc);
 
+        if let Some(timing) = &self.dispatch_timing {
+            if matches!(timing.kind(), MatMulDispatchKind::Blit) {
+                if let Some(encoder) = command_buffer.blitCommandEncoder() {
+                    unsafe {
+                        encoder.sampleCountersInBuffer_atSampleIndex_withBarrier(
+                            timing.sample_buffer(),
+                            timing.start_index(),
+                            true,
+                        );
+                    }
+                    encoder.endEncoding();
+                }
+            }
+        }
+
         // Encode the MPS matrix multiplication
         unsafe {
             self.gemm.setBatchStart(0 as NSUInteger);
             self.gemm.setBatchSize(self.batch_size as NSUInteger);
         }
         encode_mps_matrix_multiplication(&self.gemm, command_buffer, &left, &right, &result);
+
+        if let Some(timing) = &self.dispatch_timing {
+            if matches!(timing.kind(), MatMulDispatchKind::Blit) {
+                if let Some(encoder) = command_buffer.blitCommandEncoder() {
+                    unsafe {
+                        encoder.sampleCountersInBuffer_atSampleIndex_withBarrier(
+                            timing.sample_buffer(),
+                            timing.end_index(),
+                            false,
+                        );
+                    }
+                    encoder.endEncoding();
+                }
+            }
+        }
 
         Ok(())
     }

--- a/src/metallic/tests/generation_test.rs
+++ b/src/metallic/tests/generation_test.rs
@@ -216,14 +216,20 @@ fn matmul_sample_aggregation_sums_backend_totals() {
         MatMulSample {
             backend: MatMulBackend::Mps,
             duration: Duration::from_millis(8),
+            dims: None,
+            handle: None,
         },
         MatMulSample {
             backend: MatMulBackend::Mps,
             duration: Duration::from_millis(4),
+            dims: None,
+            handle: None,
         },
         MatMulSample {
             backend: MatMulBackend::Mps,
             duration: Duration::from_millis(0),
+            dims: None,
+            handle: None,
         },
     ]);
 


### PR DESCRIPTION
## Summary
- extend matmul instrumentation to track per-dispatch metadata, GPU timestamp samples, and propagate shapes/handles
- wire MLX, MPS, and GEMV kernels to register dispatches with sampling buffers and emit counter samples around the work
- update context logging to avoid synchronize() and surface rich samples to metrics and logging consumers

## Testing
- not run (Metal APIs unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e166f18e8c8326b09a26fe8b7ed1ef