### PR TITLE
Improve memory instrumentation sampling throughput

### DIFF
--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -507,7 +507,7 @@ where
     }
 
     // Ensure KV caches start from a clean slate between generations.
-    ctx.kv_caches.clear();
+    ctx.clear_kv_caches();
     ctx.kv_cache_pool.reset();
 
     let log_interval = log_interval_from_env();
@@ -643,7 +643,7 @@ where
 
         let hidden_states = qwen.forward_step(&input_tensor, current_pos, ctx)?;
         let forward_snapshot = latency_collector.borrow().snapshot();
-        let memory_snapshot = memory_collector.borrow().snapshot();
+        let memory_snapshot = memory_collector.borrow_mut().snapshot();
         ctx.set_latency_collector(None);
         ctx.set_memory_collector(None);
 

--- a/src/metallic/models/qwen25/qwen25_tests.rs
+++ b/src/metallic/models/qwen25/qwen25_tests.rs
@@ -313,7 +313,7 @@ fn test_forward_step_records_kv_repeat_phase() -> Result<(), MetalError> {
     ctx.synchronize();
     ctx.set_latency_collector(None);
 
-    let snapshot = collector.borrow().snapshot();
+    let snapshot = collector.borrow_mut().snapshot();
     assert_eq!(snapshot.blocks.len(), model.config.n_layers);
     let has_kv_repeat = snapshot.blocks[0].phases.iter().any(|phase| phase.label == "kv_repeat");
     assert!(has_kv_repeat, "kv_repeat phase was not recorded");

--- a/src/metallic/tests/forward_pass_correctness_test.rs
+++ b/src/metallic/tests/forward_pass_correctness_test.rs
@@ -1490,7 +1490,7 @@ fn test_forward_step_kv_cache_matches_pytorch_logits() -> Result<(), crate::meta
     for (pos, _) in input_ids.iter().enumerate() {
         ctx.reset_pool();
         ctx.clear_cache();
-        ctx.kv_caches.clear();
+        ctx.clear_kv_caches();
         ctx.kv_cache_pool.reset();
 
         let prefix = &input_ids[..=pos];
@@ -1506,7 +1506,7 @@ fn test_forward_step_kv_cache_matches_pytorch_logits() -> Result<(), crate::meta
 
     ctx.reset_pool();
     ctx.clear_cache();
-    ctx.kv_caches.clear();
+    ctx.clear_kv_caches();
     ctx.kv_cache_pool.reset();
 
     // Prepare KV cache pool for incremental forward steps.
@@ -1518,7 +1518,7 @@ fn test_forward_step_kv_cache_matches_pytorch_logits() -> Result<(), crate::meta
     let kv_head_dim = kv_dim / n_kv_heads;
     let batch_size = 1;
 
-    ctx.kv_caches.clear();
+    ctx.clear_kv_caches();
     ctx.kv_cache_pool.reset();
     let kv_capacity = input_ids.len().max(1);
     for layer_idx in 0..n_layers {

--- a/src/metallic/tests/generation_test.rs
+++ b/src/metallic/tests/generation_test.rs
@@ -142,7 +142,7 @@ fn test_full_generation_correctness() -> Result<(), crate::metallic::MetalError>
 
     // --- Run 2: KV Cache Implementation ---
     // Reset context to ensure a clean run
-    ctx.kv_caches.clear();
+    ctx.clear_kv_caches();
     let kv_cache_new_ids =
         crate::metallic::generation::generate_autoregressive_with_kv_cache(&mut model, &tokenizer, &mut ctx, &input_ids, &gen_cfg, &[])?;
     let mut kv_cache_ids = input_ids.clone();


### PR DESCRIPTION
## Summary
- add cached pool/KV usage tracking in the Metal context and send memory samples asynchronously
- update `StepMemoryCollector` to drain queued snapshots outside the forward loop
- adjust generation and tests to use the new KV cache helpers and async collector snapshots

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e17904a3e0832683133dedf6c58388