### PR TITLE
Accelerate sampling with GPU kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,7 @@ harness = false
 [[bench]]
 name = "mlx_vs_mps_matmul_benchmark"
 harness = false
+
+[[bench]]
+name = "sampling_benchmark"
+harness = false

--- a/benches/sampling_benchmark.rs
+++ b/benches/sampling_benchmark.rs
@@ -1,0 +1,67 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use test_burn::metallic::kernels::sampling::MAX_TOP_K;
+use test_burn::metallic::sampling::{SamplerBuffers, sample_top_k_top_p_with_random_value};
+use test_burn::metallic::{Context, F32Element, Tensor, TensorInit, TensorStorage};
+
+const ITERATIONS: usize = 32;
+const VOCAB_SIZE: usize = MAX_TOP_K * 4;
+const TOP_K: usize = 40;
+const TOP_P: f32 = 0.9;
+const TEMPERATURE: f32 = 0.85;
+const RNG_SEED: u64 = 0x5EED_FACED;
+
+fn prepare_logits_tensor(ctx: &Context<F32Element>) -> Tensor<F32Element> {
+    let logits: Vec<f32> = (0..VOCAB_SIZE).map(|i| ((i % 97) as f32) * 0.021 - 1.3).collect();
+    Tensor::new(vec![VOCAB_SIZE], TensorStorage::Dedicated(ctx), TensorInit::CopyFrom(&logits)).expect("failed to allocate logits tensor")
+}
+
+fn bench_cpu_sampling(ctx: &mut Context<F32Element>, logits_tensor: &Tensor<F32Element>) {
+    let mut buffers = SamplerBuffers::default();
+    ctx.reseed_sampler(RNG_SEED);
+
+    for _ in 0..ITERATIONS {
+        let random = ctx.next_sampler_random();
+        let logits_host = logits_tensor.to_vec();
+        let token =
+            sample_top_k_top_p_with_random_value::<F32Element>(&logits_host[..VOCAB_SIZE], TOP_K, TOP_P, TEMPERATURE, random, &mut buffers);
+        black_box(token);
+    }
+}
+
+fn bench_gpu_sampling(ctx: &mut Context<F32Element>, logits_tensor: &Tensor<F32Element>) {
+    ctx.reseed_sampler(RNG_SEED);
+
+    for _ in 0..ITERATIONS {
+        let random = ctx.next_sampler_random();
+        let token = ctx
+            .sample_top_k_top_p_device(logits_tensor, VOCAB_SIZE, TOP_K, TOP_P, TEMPERATURE, random)
+            .expect("device sampling should not fail")
+            .expect("kernel must return a token");
+        black_box(token);
+    }
+}
+
+fn sampling_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sampling_device_vs_cpu");
+    let mut context = Context::<F32Element>::new().expect("metal context");
+    let logits_tensor = prepare_logits_tensor(&context);
+
+    group.bench_function("cpu_host_sampling", |b| {
+        b.iter(|| {
+            context.pool.reset();
+            bench_cpu_sampling(&mut context, &logits_tensor);
+        })
+    });
+
+    group.bench_function("gpu_kernel_sampling", |b| {
+        b.iter(|| {
+            context.pool.reset();
+            bench_gpu_sampling(&mut context, &logits_tensor);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(sampling_benches, sampling_benchmarks);
+criterion_main!(sampling_benches);

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -389,7 +389,13 @@ impl<T: TensorElement> Context<T> {
         Ok(idx as u32)
     }
 
-    pub(crate) fn sample_top_k_top_p_device(
+    /// Attempt to sample the next token using the GPU sampling kernel.
+    ///
+    /// Returns `Ok(Some(token))` when the device kernel handled the request.
+    /// When the current tensor dtype or requested `top_k` are unsupported the
+    /// method returns `Ok(None)` so the caller can fall back to the host
+    /// sampling implementation.
+    pub fn sample_top_k_top_p_device(
         &mut self,
         logits: &Tensor<T>,
         vocab_size: usize,

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -455,10 +455,12 @@ impl<T: TensorElement> Context<T> {
         let params = SamplingParams {
             vocab_size: vocab_size as u32,
             top_k: top_k as u32,
+            random_u32,
+            threadgroup_count: 0,
             top_p,
             temperature,
-            random_u32,
-            _padding: 0,
+            _padding0: 0,
+            _padding1: 0,
         };
 
         let logits_view = logits.clone();

--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -317,6 +317,9 @@ impl<T: TensorElement> Context<T> {
         });
         let matmul_instrumentation = MatMulInstrumentation::new(Some(&device));
 
+        let mut seeding_rng = rand::rng();
+        let sampler_seed = seeding_rng.next_u64();
+
         Ok(Context::<T> {
             device,
             command_queue,
@@ -339,7 +342,7 @@ impl<T: TensorElement> Context<T> {
             matmul_recorder,
             matmul_logging_session: RefCell::new(None),
             sampler_buffers: SamplerBuffers::default(),
-            sampler_rng: StdRng::from_entropy(),
+            sampler_rng: StdRng::seed_from_u64(sampler_seed),
             sampling_result_buffer: None,
             forced_matmul_backend: forced_backend,
             log_matmul_shapes,
@@ -467,7 +470,7 @@ impl<T: TensorElement> Context<T> {
         command_buffer.commit();
         command_buffer.wait();
 
-        let ptr = unsafe { result_buffer.contents().as_ptr().cast::<u32>() };
+        let ptr = result_buffer.contents().as_ptr().cast::<u32>();
         let token = unsafe { ptr.read_unaligned() };
         Ok(Some(token))
     }

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -9,7 +9,7 @@ use crate::metallic::metrics::{
     ScalarStat, build_latency_rows, build_memory_rows, build_model_memory_tree, log_interval_from_env, sample_process_memory,
 };
 use crate::metallic::models::qwen25::Qwen25;
-use crate::metallic::sampling::{effective_top_k, sample_top_k_top_p};
+use crate::metallic::sampling::effective_top_k;
 use crate::metallic::tensor::Dtype;
 use crate::metallic::{TensorElement, Tokenizer};
 use crate::{alert, app_event::AppEvent};

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -463,6 +463,7 @@ where
 
         if use_device {
             ctx.synchronize();
+            record_matmul_samples(&mut matmul_backend_stats, ctx.take_matmul_samples());
         }
 
         let sample_start = Instant::now();
@@ -476,6 +477,7 @@ where
             random,
             use_device,
         )?;
+        record_matmul_samples(&mut matmul_backend_stats, ctx.take_matmul_samples());
         let sample_duration = sample_start.elapsed();
         if !sample_duration.is_zero() {
             sample_stats.record(sample_duration);
@@ -623,6 +625,7 @@ where
 
         if use_device {
             ctx.synchronize();
+            record_matmul_samples(&mut matmul_backend_stats, ctx.take_matmul_samples());
         }
 
         let random = ctx.next_sampler_random();
@@ -637,6 +640,7 @@ where
             random,
             use_device,
         )?;
+        record_matmul_samples(&mut matmul_backend_stats, ctx.take_matmul_samples());
 
         generated_ids.push(next_token);
 

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -150,6 +150,8 @@ fn sample_next_token_from_logits<T: TensorElement>(
         }
     }
 
+    ctx.synchronize();
+
     let start = Instant::now();
     let token = ctx.sample_top_k_top_p_host(logits_tensor, vocab_size, top_k, top_p, temperature, random)?;
     let duration = start.elapsed();

--- a/src/metallic/generation.rs
+++ b/src/metallic/generation.rs
@@ -165,7 +165,7 @@ fn sample_next_token_from_logits<T: TensorElement>(
 
 #[inline]
 fn should_use_device_sampling<T: TensorElement>(vocab_size: usize, top_k: usize) -> bool {
-    vocab_size > 0 && T::DTYPE == Dtype::F32 && effective_top_k(top_k, vocab_size) <= MAX_TOP_K
+    vocab_size > 0 && matches!(T::DTYPE, Dtype::F32 | Dtype::F16) && effective_top_k(top_k, vocab_size) <= MAX_TOP_K
 }
 
 fn log_cache_stats<T: TensorElement>(ctx: &Context<T>, phase: &str, step: usize) {

--- a/src/metallic/instrumentation.rs
+++ b/src/metallic/instrumentation.rs
@@ -200,16 +200,17 @@ impl MatMulInstrumentation {
             } = dispatch;
 
             if let Some(timing) = timing.as_ref()
-                && let Some(duration) = self.inner.resolve_duration(timing) {
-                    recorder.record(MatMulSample {
-                        backend,
-                        duration,
-                        dims,
-                        handle: Some(handle),
-                    });
-                    resolved_total += duration;
-                    continue;
-                }
+                && let Some(duration) = self.inner.resolve_duration(timing)
+            {
+                recorder.record(MatMulSample {
+                    backend,
+                    duration,
+                    dims,
+                    handle: Some(handle),
+                });
+                resolved_total += duration;
+                continue;
+            }
 
             fallback.push(PendingDispatch {
                 handle,
@@ -715,13 +716,11 @@ impl BlockLatencySnapshot {
     }
 }
 
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BlockPhaseSnapshot {
     pub label: String,
     pub duration: Duration,
 }
-
 
 /// Helper to create a new collector handle for the desired number of transformer blocks.
 pub fn new_latency_collector(block_count: usize) -> LatencyCollectorHandle {
@@ -1086,8 +1085,7 @@ impl BlockMemorySnapshot {
     }
 }
 
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MemoryPhaseSnapshot {
     pub label: String,
     pub current_pool_delta: usize,
@@ -1097,7 +1095,6 @@ pub struct MemoryPhaseSnapshot {
     pub peak_kv_delta: usize,
     pub peak_kv_cache_delta: usize,
 }
-
 
 #[derive(Clone, Debug, Default)]
 pub struct StepMemorySnapshot {

--- a/src/metallic/instrumentation.rs
+++ b/src/metallic/instrumentation.rs
@@ -126,9 +126,16 @@ pub type MatMulDispatchRegistration = KernelDispatchRegistration;
 pub type MatMulDispatchTiming = KernelDispatchTiming;
 pub type MatMulInstrumentation = KernelInstrumentation<MatMulSample>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SamplingBackend {
+    Kernel,
+    Cpu,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct SamplingSample {
     pub duration: Duration,
+    pub backend: SamplingBackend,
     pub handle: Option<KernelDispatchHandle>,
 }
 
@@ -297,6 +304,7 @@ impl KernelInstrumentation<SamplingSample> {
         self.register_dispatch(command_buffer, KernelDispatchKind::Compute, recorder, |duration, handle| {
             SamplingSample {
                 duration,
+                backend: SamplingBackend::Kernel,
                 handle: Some(handle),
             }
         })

--- a/src/metallic/kernels/gemv/mod.rs
+++ b/src/metallic/kernels/gemv/mod.rs
@@ -43,17 +43,18 @@ impl<T: TensorElement> Operation for Gemv<T> {
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.start_index(),
-                        withBarrier: Bool::YES
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
             }
+        }
 
         set_compute_pipeline_state(&encoder, &self.pipeline);
         set_buffer(&encoder, 0, &self.a.buf, self.a.offset);
@@ -64,17 +65,18 @@ impl<T: TensorElement> Operation for Gemv<T> {
         dispatch_threadgroups(&encoder, self.grid_size, self.threadgroup_size);
 
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.end_index(),
-                        withBarrier: Bool::NO
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
             }
+        }
 
         encoder.endEncoding();
         Ok(())

--- a/src/metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -211,18 +211,19 @@ impl Operation for MatMulAlphaBeta {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.start_index(),
-                            withBarrier: Bool::YES
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         // Encode the MPS matrix multiplication
         unsafe {
@@ -233,18 +234,19 @@ impl Operation for MatMulAlphaBeta {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.end_index(),
-                            withBarrier: Bool::NO
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         Ok(())
     }

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -240,18 +240,19 @@ impl Operation for MatMul {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.start_index(),
-                            withBarrier: Bool::YES
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         // Encode the MPS matrix multiplication
         unsafe {
@@ -262,18 +263,19 @@ impl Operation for MatMul {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.end_index(),
-                            withBarrier: Bool::NO
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         Ok(())
     }

--- a/src/metallic/kernels/mlxmatmul/mlx.rs
+++ b/src/metallic/kernels/mlxmatmul/mlx.rs
@@ -435,17 +435,18 @@ impl<T: TensorElement> Operation for MatMulMlx<T> {
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.start_index(),
-                        withBarrier: Bool::YES
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
             }
+        }
 
         set_compute_pipeline_state(&encoder, &self.pipeline);
         set_buffer(&encoder, 0, &self.left.buf, self.left.offset);
@@ -482,17 +483,18 @@ impl<T: TensorElement> Operation for MatMulMlx<T> {
 
         dispatch_threadgroups(&encoder, self.threadgroups, self.threads_per_tg);
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.end_index(),
-                        withBarrier: Bool::NO
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
             }
+        }
         encoder.endEncoding();
         Ok(())
     }

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -1,6 +1,6 @@
 use crate::metallic::{
     Context, Dtype, MetalError, Operation, Tensor,
-    encoder::{dispatch_threadgroups, dispatch_threads, set_buffer, set_bytes, set_compute_pipeline_state},
+    encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_compute_pipeline_state},
     resource_cache::ResourceCache,
 };
 use objc2::rc::Retained;

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -198,12 +198,9 @@ impl KernelFunction {
             (KernelFunction::Gemv, F32) => "gemv_f32",
             (KernelFunction::Gemv, F16) => "gemv_f16",
             (KernelFunction::SampleTopKTopPStage1, F32) => "sample_top_k_top_p_stage1_f32",
+            (KernelFunction::SampleTopKTopPStage1, F16) => "sample_top_k_top_p_stage1_f16",
             (KernelFunction::SampleTopKTopPFinalize, F32) => "sample_top_k_top_p_finalize_f32",
-            (KernelFunction::SampleTopKTopPStage1 | KernelFunction::SampleTopKTopPFinalize, F16) => {
-                return Err(MetalError::OperationNotSupported(
-                    "top-k/top-p sampling kernel does not support f16 logits".to_string(),
-                ));
-            }
+            (KernelFunction::SampleTopKTopPFinalize, F16) => "sample_top_k_top_p_finalize_f16",
         };
 
         Ok(name)

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -1,6 +1,6 @@
 use crate::metallic::{
     Context, Dtype, MetalError, Operation, Tensor,
-    encoder::{dispatch_threadgroups, set_buffer, set_bytes, set_compute_pipeline_state},
+    encoder::{dispatch_threadgroups, dispatch_threads, set_buffer, set_bytes, set_compute_pipeline_state},
     resource_cache::ResourceCache,
 };
 use objc2::rc::Retained;

--- a/src/metallic/kernels/mod.rs
+++ b/src/metallic/kernels/mod.rs
@@ -114,7 +114,8 @@ pub enum KernelFunction {
     Ones,
     RandomUniform,
     Gemv,
-    SampleTopKTopP,
+    SampleTopKTopPStage1,
+    SampleTopKTopPFinalize,
 }
 
 impl KernelFunction {
@@ -140,7 +141,7 @@ impl KernelFunction {
             KernelFunction::SwigluFusedActivation => KernelLibrary::Swiglu,
             KernelFunction::Arange | KernelFunction::Ones | KernelFunction::RandomUniform => KernelLibrary::Tensors,
             KernelFunction::Gemv => KernelLibrary::Gemv,
-            KernelFunction::SampleTopKTopP => KernelLibrary::Sampling,
+            KernelFunction::SampleTopKTopPStage1 | KernelFunction::SampleTopKTopPFinalize => KernelLibrary::Sampling,
         }
     }
 
@@ -196,8 +197,9 @@ impl KernelFunction {
             (KernelFunction::RandomUniform, F16) => "random_uniform_f16",
             (KernelFunction::Gemv, F32) => "gemv_f32",
             (KernelFunction::Gemv, F16) => "gemv_f16",
-            (KernelFunction::SampleTopKTopP, F32) => "sample_top_k_top_p_f32",
-            (KernelFunction::SampleTopKTopP, F16) => {
+            (KernelFunction::SampleTopKTopPStage1, F32) => "sample_top_k_top_p_stage1_f32",
+            (KernelFunction::SampleTopKTopPFinalize, F32) => "sample_top_k_top_p_finalize_f32",
+            (KernelFunction::SampleTopKTopPStage1 | KernelFunction::SampleTopKTopPFinalize, F16) => {
                 return Err(MetalError::OperationNotSupported(
                     "top-k/top-p sampling kernel does not support f16 logits".to_string(),
                 ));

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -3,7 +3,7 @@
 using namespace metal;
 
 constant uint MAX_TOP_K = 256;
-constant uint THREADGROUP_SIZE = 32;
+constant uint THREADGROUP_SIZE = 8;
 
 struct SamplingParams {
     uint vocab_size;

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -1,37 +1,52 @@
 #include <metal_stdlib>
+#include <metal_atomic>
 using namespace metal;
 
 constant uint MAX_TOP_K = 256;
-constant uint THREADGROUP_SIZE = 8;
+constant uint THREADGROUP_SIZE = 32;
 
 struct SamplingParams {
     uint vocab_size;
     uint top_k;
+    uint random_u32;
+    uint threadgroup_count;
     float top_p;
     float temperature;
-    uint random_u32;
-    uint _padding;
+    uint _padding0;
+    uint _padding1;
 };
 
 kernel void sample_top_k_top_p_f32(
     device const float* logits [[buffer(0)]],
     device uint* output [[buffer(1)]],
-    constant SamplingParams& params [[buffer(2)]],
+    device float* partial_vals [[buffer(2)]],
+    device uint* partial_indices [[buffer(3)]],
+    device uint* partial_counts [[buffer(4)]],
+    device float* fallback_vals [[buffer(5)]],
+    device uint* fallback_indices [[buffer(6)]],
+    device uint* fallback_flags [[buffer(7)]],
+    device atomic_uint* completion_counter [[buffer(8)]],
+    constant SamplingParams& params [[buffer(9)]],
     uint tid [[thread_index_in_threadgroup]],
     uint3 tg_pos [[threadgroup_position_in_grid]])
 {
-    if (tg_pos.x != 0u || tg_pos.y != 0u || tg_pos.z != 0u) {
-        return;
-    }
-
     uint vocab_size = params.vocab_size;
     if (vocab_size == 0u) {
         output[0] = 0u;
         return;
     }
 
-    float temperature = params.temperature;
+    uint threadgroup_index = tg_pos.x;
+    uint threadgroup_count = max(params.threadgroup_count, 1u);
+    if (threadgroup_index >= threadgroup_count) {
+        return;
+    }
+
+    uint total_threads = threadgroup_count * THREADGROUP_SIZE;
+    uint global_thread = threadgroup_index * THREADGROUP_SIZE + tid;
+
     uint requested_top_k = params.top_k;
+    float temperature = params.temperature;
     bool skip_sampling = false;
     if (!isfinite(temperature) || temperature <= 0.0f) {
         skip_sampling = true;
@@ -48,16 +63,16 @@ kernel void sample_top_k_top_p_f32(
         effective_top_k = vocab_size;
     }
     if (effective_top_k > MAX_TOP_K) {
-        skip_sampling = true;
         effective_top_k = MAX_TOP_K;
+        skip_sampling = true;
     }
 
     threadgroup float shared_vals[THREADGROUP_SIZE * MAX_TOP_K];
     threadgroup uint shared_indices[THREADGROUP_SIZE * MAX_TOP_K];
-    threadgroup ushort shared_counts[THREADGROUP_SIZE];
+    threadgroup uint shared_counts[THREADGROUP_SIZE];
     threadgroup float shared_fallback_vals[THREADGROUP_SIZE];
     threadgroup uint shared_fallback_indices[THREADGROUP_SIZE];
-    threadgroup uchar shared_fallback_flags[THREADGROUP_SIZE];
+    threadgroup uint shared_fallback_flags[THREADGROUP_SIZE];
 
     thread float local_vals[MAX_TOP_K];
     thread uint local_indices[MAX_TOP_K];
@@ -67,7 +82,7 @@ kernel void sample_top_k_top_p_f32(
     uint local_fallback_idx = 0u;
     float inv_temp = skip_sampling ? 0.0f : 1.0f / temperature;
 
-    for (uint index = tid; index < vocab_size; index += THREADGROUP_SIZE) {
+    for (uint index = global_thread; index < vocab_size; index += total_threads) {
         float logit = logits[index];
         if (isfinite(logit) && (!local_fallback_found || logit > local_fallback_val ||
                                 (logit == local_fallback_val && index > local_fallback_idx))) {
@@ -92,8 +107,8 @@ kernel void sample_top_k_top_p_f32(
 
         if (local_count < effective_top_k) {
             for (uint j = local_count; j > insert_pos; --j) {
-                local_vals[j] = local_vals[j - 1];
-                local_indices[j] = local_indices[j - 1];
+                local_vals[j] = local_vals[j - 1u];
+                local_indices[j] = local_indices[j - 1u];
             }
             local_vals[insert_pos] = scaled_val;
             local_indices[insert_pos] = index;
@@ -108,160 +123,232 @@ kernel void sample_top_k_top_p_f32(
         }
     }
 
-    shared_counts[tid] = static_cast<ushort>(local_count);
+    shared_counts[tid] = local_count;
     shared_fallback_vals[tid] = local_fallback_val;
     shared_fallback_indices[tid] = local_fallback_idx;
     shared_fallback_flags[tid] = local_fallback_found ? 1u : 0u;
 
-    uint base = tid * MAX_TOP_K;
+    uint shared_base = tid * MAX_TOP_K;
     for (uint i = 0u; i < local_count; ++i) {
-        shared_vals[base + i] = local_vals[i];
-        shared_indices[base + i] = local_indices[i];
+        shared_vals[shared_base + i] = local_vals[i];
+        shared_indices[shared_base + i] = local_indices[i];
     }
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (tid != 0u) {
-        return;
-    }
-
-    bool fallback_found = false;
-    float fallback_val = -INFINITY;
-    uint fallback_idx = 0u;
-    for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
-        if (shared_fallback_flags[t] == 0u) {
-            continue;
-        }
-        float candidate_val = shared_fallback_vals[t];
-        uint candidate_idx = shared_fallback_indices[t];
-        if (!fallback_found || candidate_val > fallback_val ||
-            (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
-            fallback_found = true;
-            fallback_val = candidate_val;
-            fallback_idx = candidate_idx;
-        }
-    }
-
-    if (!fallback_found) {
-        fallback_idx = 0u;
-    }
-
-    if (skip_sampling) {
-        output[0] = fallback_found ? fallback_idx : 0u;
-        return;
-    }
-
-    thread float shortlist_vals[MAX_TOP_K];
-    thread uint shortlist_indices[MAX_TOP_K];
-    uint shortlist_count = 0u;
-
-    for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
-        uint count = shared_counts[t];
-        uint offset = t * MAX_TOP_K;
-        for (uint i = 0u; i < count; ++i) {
-            float val = shared_vals[offset + i];
-            uint idx = shared_indices[offset + i];
-
-            uint insert_pos = 0u;
-            while (insert_pos < shortlist_count && shortlist_vals[insert_pos] > val) {
-                ++insert_pos;
+    if (tid == 0u) {
+        bool fallback_found = false;
+        float fallback_val = -INFINITY;
+        uint fallback_idx = 0u;
+        for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
+            if (shared_fallback_flags[t] == 0u) {
+                continue;
             }
-
-            if (shortlist_count < effective_top_k) {
-                for (uint j = shortlist_count; j > insert_pos; --j) {
-                    shortlist_vals[j] = shortlist_vals[j - 1];
-                    shortlist_indices[j] = shortlist_indices[j - 1];
-                }
-                shortlist_vals[insert_pos] = val;
-                shortlist_indices[insert_pos] = idx;
-                ++shortlist_count;
-            } else if (insert_pos < effective_top_k) {
-                for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
-                    shortlist_vals[j] = shortlist_vals[j - 1u];
-                    shortlist_indices[j] = shortlist_indices[j - 1u];
-                }
-                shortlist_vals[insert_pos] = val;
-                shortlist_indices[insert_pos] = idx;
+            float candidate_val = shared_fallback_vals[t];
+            uint candidate_idx = shared_fallback_indices[t];
+            if (!fallback_found || candidate_val > fallback_val ||
+                (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
+                fallback_found = true;
+                fallback_val = candidate_val;
+                fallback_idx = candidate_idx;
             }
         }
-    }
 
-    if (shortlist_count == 0u) {
-        output[0] = fallback_found ? fallback_idx : 0u;
-        return;
-    }
+        thread float shortlist_vals[MAX_TOP_K];
+        thread uint shortlist_indices[MAX_TOP_K];
+        uint shortlist_count = 0u;
 
-    float max_val = shortlist_vals[0];
-    for (uint i = 1u; i < shortlist_count; ++i) {
-        if (shortlist_vals[i] > max_val) {
-            max_val = shortlist_vals[i];
+        for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
+            uint count = shared_counts[t];
+            uint offset = t * MAX_TOP_K;
+            for (uint i = 0u; i < count; ++i) {
+                float val = shared_vals[offset + i];
+                uint idx = shared_indices[offset + i];
+
+                uint insert_pos = 0u;
+                while (insert_pos < shortlist_count && shortlist_vals[insert_pos] > val) {
+                    ++insert_pos;
+                }
+
+                if (shortlist_count < effective_top_k) {
+                    for (uint j = shortlist_count; j > insert_pos; --j) {
+                        shortlist_vals[j] = shortlist_vals[j - 1u];
+                        shortlist_indices[j] = shortlist_indices[j - 1u];
+                    }
+                    shortlist_vals[insert_pos] = val;
+                    shortlist_indices[insert_pos] = idx;
+                    ++shortlist_count;
+                } else if (insert_pos < effective_top_k) {
+                    for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
+                        shortlist_vals[j] = shortlist_vals[j - 1u];
+                        shortlist_indices[j] = shortlist_indices[j - 1u];
+                    }
+                    shortlist_vals[insert_pos] = val;
+                    shortlist_indices[insert_pos] = idx;
+                }
+            }
         }
-    }
 
-    float total = 0.0f;
-    bool has_positive = false;
-    for (uint i = 0u; i < shortlist_count; ++i) {
-        float exp_val = exp(shortlist_vals[i] - max_val);
-        if (exp_val > 1e10f) {
-            exp_val = 1e10f;
-        } else if (exp_val < 1e-10f) {
-            exp_val = 0.0f;
-        }
-        shortlist_vals[i] = exp_val;
-        total += exp_val;
-        has_positive = has_positive || exp_val > 0.0f;
-    }
-
-    if (!has_positive || total <= 0.0f || !isfinite(total)) {
-        output[0] = fallback_found ? fallback_idx : 0u;
-        return;
-    }
-
-    float normalized_top_p = params.top_p;
-    if (!isfinite(normalized_top_p)) {
-        normalized_top_p = 1.0f;
-    } else {
-        normalized_top_p = clamp(normalized_top_p, 0.0f, 1.0f);
-    }
-
-    uint cutoff = shortlist_count - 1u;
-    if (normalized_top_p <= 0.0f) {
-        cutoff = 0u;
-    } else if (normalized_top_p < 1.0f) {
-        float cumulative = 0.0f;
-        float threshold = normalized_top_p * total;
+        uint base = threadgroup_index * effective_top_k;
         for (uint i = 0u; i < shortlist_count; ++i) {
-            cumulative += shortlist_vals[i];
-            cutoff = i;
-            if (cumulative >= threshold || !isfinite(cumulative)) {
-                break;
-            }
+            partial_vals[base + i] = shortlist_vals[i];
+            partial_indices[base + i] = shortlist_indices[i];
         }
+        partial_counts[threadgroup_index] = shortlist_count;
+        fallback_vals[threadgroup_index] = fallback_val;
+        fallback_indices[threadgroup_index] = fallback_idx;
+        fallback_flags[threadgroup_index] = fallback_found ? 1u : 0u;
     }
 
-    float shortlist_total = 0.0f;
-    for (uint i = 0u; i <= cutoff; ++i) {
-        shortlist_total += shortlist_vals[i];
-    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (shortlist_total <= 0.0f || !isfinite(shortlist_total)) {
-        output[0] = shortlist_indices[0];
-        return;
-    }
-
-    for (uint i = 0u; i <= cutoff; ++i) {
-        shortlist_vals[i] /= shortlist_total;
-    }
-
-    float random_value = static_cast<float>(params.random_u32) / 4294967295.0f;
-    float acc = 0.0f;
-    for (uint i = 0u; i <= cutoff; ++i) {
-        acc += shortlist_vals[i];
-        if (random_value <= acc || !isfinite(acc)) {
-            output[0] = shortlist_indices[i];
+    if (tid == 0u) {
+        uint prev = atomic_fetch_add_explicit(completion_counter, 1u, memory_order_acq_rel);
+        bool is_last = (prev + 1u) == threadgroup_count;
+        if (!is_last) {
             return;
         }
-    }
 
-    output[0] = shortlist_indices[cutoff];
+        bool fallback_found = false;
+        float fallback_val = -INFINITY;
+        uint fallback_idx = 0u;
+        for (uint group = 0u; group < threadgroup_count; ++group) {
+            if (fallback_flags[group] == 0u) {
+                continue;
+            }
+            float candidate_val = fallback_vals[group];
+            uint candidate_idx = fallback_indices[group];
+            if (!fallback_found || candidate_val > fallback_val ||
+                (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
+                fallback_found = true;
+                fallback_val = candidate_val;
+                fallback_idx = candidate_idx;
+            }
+        }
+
+        if (skip_sampling) {
+            output[0] = fallback_found ? fallback_idx : 0u;
+            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            return;
+        }
+
+        thread float shortlist_vals[MAX_TOP_K];
+        thread uint shortlist_indices[MAX_TOP_K];
+        uint shortlist_count = 0u;
+
+        for (uint group = 0u; group < threadgroup_count; ++group) {
+            uint count = min(partial_counts[group], effective_top_k);
+            uint base = group * effective_top_k;
+            for (uint i = 0u; i < count; ++i) {
+                float val = partial_vals[base + i];
+                uint idx = partial_indices[base + i];
+
+                uint insert_pos = 0u;
+                while (insert_pos < shortlist_count && shortlist_vals[insert_pos] > val) {
+                    ++insert_pos;
+                }
+
+                if (shortlist_count < effective_top_k) {
+                    for (uint j = shortlist_count; j > insert_pos; --j) {
+                        shortlist_vals[j] = shortlist_vals[j - 1u];
+                        shortlist_indices[j] = shortlist_indices[j - 1u];
+                    }
+                    shortlist_vals[insert_pos] = val;
+                    shortlist_indices[insert_pos] = idx;
+                    ++shortlist_count;
+                } else if (insert_pos < effective_top_k) {
+                    for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
+                        shortlist_vals[j] = shortlist_vals[j - 1u];
+                        shortlist_indices[j] = shortlist_indices[j - 1u];
+                    }
+                    shortlist_vals[insert_pos] = val;
+                    shortlist_indices[insert_pos] = idx;
+                }
+            }
+        }
+
+        if (shortlist_count == 0u) {
+            output[0] = fallback_found ? fallback_idx : 0u;
+            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            return;
+        }
+
+        float max_val = shortlist_vals[0];
+        for (uint i = 1u; i < shortlist_count; ++i) {
+            if (shortlist_vals[i] > max_val) {
+                max_val = shortlist_vals[i];
+            }
+        }
+
+        float total = 0.0f;
+        bool has_positive = false;
+        for (uint i = 0u; i < shortlist_count; ++i) {
+            float exp_val = exp(shortlist_vals[i] - max_val);
+            if (exp_val > 1e10f) {
+                exp_val = 1e10f;
+            } else if (exp_val < 1e-10f) {
+                exp_val = 0.0f;
+            }
+            shortlist_vals[i] = exp_val;
+            total += exp_val;
+            has_positive = has_positive || exp_val > 0.0f;
+        }
+
+        if (!has_positive || total <= 0.0f || !isfinite(total)) {
+            output[0] = fallback_found ? fallback_idx : shortlist_indices[0];
+            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            return;
+        }
+
+        float normalized_top_p = params.top_p;
+        if (!isfinite(normalized_top_p)) {
+            normalized_top_p = 1.0f;
+        } else {
+            normalized_top_p = clamp(normalized_top_p, 0.0f, 1.0f);
+        }
+
+        uint cutoff = shortlist_count - 1u;
+        if (normalized_top_p <= 0.0f) {
+            cutoff = 0u;
+        } else if (normalized_top_p < 1.0f) {
+            float cumulative = 0.0f;
+            float threshold = normalized_top_p * total;
+            for (uint i = 0u; i < shortlist_count; ++i) {
+                cumulative += shortlist_vals[i];
+                cutoff = i;
+                if (cumulative >= threshold || !isfinite(cumulative)) {
+                    break;
+                }
+            }
+        }
+
+        float shortlist_total = 0.0f;
+        for (uint i = 0u; i <= cutoff; ++i) {
+            shortlist_total += shortlist_vals[i];
+        }
+
+        if (shortlist_total <= 0.0f || !isfinite(shortlist_total)) {
+            output[0] = shortlist_indices[0];
+            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            return;
+        }
+
+        for (uint i = 0u; i <= cutoff; ++i) {
+            shortlist_vals[i] /= shortlist_total;
+        }
+
+        float random_value = static_cast<float>(params.random_u32) / 4294967295.0f;
+        float acc = 0.0f;
+        for (uint i = 0u; i <= cutoff; ++i) {
+            acc += shortlist_vals[i];
+            if (random_value <= acc || !isfinite(acc)) {
+                output[0] = shortlist_indices[i];
+                atomic_store_explicit(completion_counter, 0u, memory_order_release);
+                return;
+            }
+        }
+
+        output[0] = shortlist_indices[cutoff];
+        atomic_store_explicit(completion_counter, 0u, memory_order_release);
+    }
 }

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -203,7 +203,7 @@ kernel void sample_top_k_top_p_f32(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     if (tid == 0u) {
-        uint prev = atomic_fetch_add_explicit(completion_counter, 1u, memory_order_acq_rel);
+        uint prev = atomic_fetch_add_explicit(completion_counter, 1u, memory_order_relaxed);
         bool is_last = (prev + 1u) == threadgroup_count;
         if (!is_last) {
             return;
@@ -228,7 +228,7 @@ kernel void sample_top_k_top_p_f32(
 
         if (skip_sampling) {
             output[0] = fallback_found ? fallback_idx : 0u;
-            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            atomic_store_explicit(completion_counter, 0u, memory_order_relaxed);
             return;
         }
 
@@ -269,7 +269,7 @@ kernel void sample_top_k_top_p_f32(
 
         if (shortlist_count == 0u) {
             output[0] = fallback_found ? fallback_idx : 0u;
-            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            atomic_store_explicit(completion_counter, 0u, memory_order_relaxed);
             return;
         }
 
@@ -296,7 +296,7 @@ kernel void sample_top_k_top_p_f32(
 
         if (!has_positive || total <= 0.0f || !isfinite(total)) {
             output[0] = fallback_found ? fallback_idx : shortlist_indices[0];
-            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            atomic_store_explicit(completion_counter, 0u, memory_order_relaxed);
             return;
         }
 
@@ -329,7 +329,7 @@ kernel void sample_top_k_top_p_f32(
 
         if (shortlist_total <= 0.0f || !isfinite(shortlist_total)) {
             output[0] = shortlist_indices[0];
-            atomic_store_explicit(completion_counter, 0u, memory_order_release);
+            atomic_store_explicit(completion_counter, 0u, memory_order_relaxed);
             return;
         }
 
@@ -343,12 +343,12 @@ kernel void sample_top_k_top_p_f32(
             acc += shortlist_vals[i];
             if (random_value <= acc || !isfinite(acc)) {
                 output[0] = shortlist_indices[i];
-                atomic_store_explicit(completion_counter, 0u, memory_order_release);
+                atomic_store_explicit(completion_counter, 0u, memory_order_relaxed);
                 return;
             }
         }
 
         output[0] = shortlist_indices[cutoff];
-        atomic_store_explicit(completion_counter, 0u, memory_order_release);
+        atomic_store_explicit(completion_counter, 0u, memory_order_relaxed);
     }
 }

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -20,7 +20,7 @@ struct SamplingParams {
 
 kernel void sample_top_k_top_p_stage1_f32(
     device const float* logits [[buffer(0)]],
-    device uint* /*output*/ [[buffer(1)]],
+    device uint* unused_output [[buffer(1)]],
     device float* partial_vals [[buffer(2)]],
     device uint* partial_indices [[buffer(3)]],
     device uint* partial_counts [[buffer(4)]],
@@ -31,6 +31,8 @@ kernel void sample_top_k_top_p_stage1_f32(
     uint tid [[thread_index_in_threadgroup]],
     uint3 tg_pos [[threadgroup_position_in_grid]])
 {
+    (void)unused_output;
+
     uint vocab_size = params.vocab_size;
     if (vocab_size == 0u) {
         return;
@@ -219,7 +221,7 @@ kernel void sample_top_k_top_p_stage1_f32(
 }
 
 kernel void sample_top_k_top_p_finalize_f32(
-    device const float* /*logits*/ [[buffer(0)]],
+    device const float* logits [[buffer(0)]],
     device uint* output [[buffer(1)]],
     device const float* partial_vals [[buffer(2)]],
     device const uint* partial_indices [[buffer(3)]],
@@ -230,6 +232,8 @@ kernel void sample_top_k_top_p_finalize_f32(
     constant SamplingParams& params [[buffer(9)]],
     uint tid [[thread_index_in_threadgroup]])
 {
+    (void)logits;
+
     if (tid != 0u) {
         return;
     }

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -2,6 +2,7 @@
 using namespace metal;
 
 constant uint MAX_TOP_K = 256;
+constant uint THREADGROUP_SIZE = 8;
 
 struct SamplingParams {
     uint vocab_size;
@@ -16,41 +17,27 @@ kernel void sample_top_k_top_p_f32(
     device const float* logits [[buffer(0)]],
     device uint* output [[buffer(1)]],
     constant SamplingParams& params [[buffer(2)]],
-    uint tid [[thread_position_in_grid]])
+    uint tid [[thread_index_in_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]])
 {
-    if (tid != 0) {
+    if (tg_pos.x != 0u || tg_pos.y != 0u || tg_pos.z != 0u) {
         return;
     }
 
     uint vocab_size = params.vocab_size;
-    if (vocab_size == 0) {
+    if (vocab_size == 0u) {
         output[0] = 0u;
         return;
     }
 
     float temperature = params.temperature;
     uint requested_top_k = params.top_k;
-
-    uint fallback_idx = 0u;
-    bool fallback_found = false;
-    float fallback_val = -INFINITY;
-    for (uint i = 0; i < vocab_size; ++i) {
-        float val = logits[i];
-        if (isfinite(val) && (!fallback_found || val > fallback_val || (val == fallback_val && i > fallback_idx))) {
-            fallback_idx = i;
-            fallback_val = val;
-            fallback_found = true;
-        }
-    }
-
+    bool skip_sampling = false;
     if (!isfinite(temperature) || temperature <= 0.0f) {
-        output[0] = fallback_found ? fallback_idx : 0u;
-        return;
+        skip_sampling = true;
     }
-
     if (requested_top_k == 0u) {
-        output[0] = fallback_found ? fallback_idx : 0u;
-        return;
+        skip_sampling = true;
     }
 
     uint effective_top_k = requested_top_k;
@@ -61,61 +48,166 @@ kernel void sample_top_k_top_p_f32(
         effective_top_k = vocab_size;
     }
     if (effective_top_k > MAX_TOP_K) {
-        output[0] = fallback_found ? fallback_idx : 0u;
-        return;
+        skip_sampling = true;
+        effective_top_k = MAX_TOP_K;
     }
 
-    thread float scaled[MAX_TOP_K];
-    thread uint indices[MAX_TOP_K];
-    uint count = 0u;
-    float inv_temp = 1.0f / temperature;
+    threadgroup float shared_vals[THREADGROUP_SIZE * MAX_TOP_K];
+    threadgroup uint shared_indices[THREADGROUP_SIZE * MAX_TOP_K];
+    threadgroup ushort shared_counts[THREADGROUP_SIZE];
+    threadgroup float shared_fallback_vals[THREADGROUP_SIZE];
+    threadgroup uint shared_fallback_indices[THREADGROUP_SIZE];
+    threadgroup uchar shared_fallback_flags[THREADGROUP_SIZE];
 
-    for (uint i = 0; i < vocab_size; ++i) {
-        float scaled_val = logits[i] * inv_temp;
+    thread float local_vals[MAX_TOP_K];
+    thread uint local_indices[MAX_TOP_K];
+    uint local_count = 0u;
+    bool local_fallback_found = false;
+    float local_fallback_val = -INFINITY;
+    uint local_fallback_idx = 0u;
+    float inv_temp = skip_sampling ? 0.0f : 1.0f / temperature;
+
+    for (uint index = tid; index < vocab_size; index += THREADGROUP_SIZE) {
+        float logit = logits[index];
+        if (isfinite(logit) && (!local_fallback_found || logit > local_fallback_val ||
+                                (logit == local_fallback_val && index > local_fallback_idx))) {
+            local_fallback_found = true;
+            local_fallback_val = logit;
+            local_fallback_idx = index;
+        }
+
+        if (skip_sampling) {
+            continue;
+        }
+
+        float scaled_val = logit * inv_temp;
         if (!isfinite(scaled_val)) {
             continue;
         }
 
         uint insert_pos = 0u;
-        while (insert_pos < count && scaled[insert_pos] > scaled_val) {
+        while (insert_pos < local_count && local_vals[insert_pos] > scaled_val) {
             ++insert_pos;
         }
 
-        if (count < effective_top_k) {
-            for (uint j = count; j > insert_pos; --j) {
-                scaled[j] = scaled[j - 1];
-                indices[j] = indices[j - 1];
+        if (local_count < effective_top_k) {
+            for (uint j = local_count; j > insert_pos; --j) {
+                local_vals[j] = local_vals[j - 1];
+                local_indices[j] = local_indices[j - 1];
             }
-            scaled[insert_pos] = scaled_val;
-            indices[insert_pos] = i;
-            ++count;
+            local_vals[insert_pos] = scaled_val;
+            local_indices[insert_pos] = index;
+            ++local_count;
         } else if (insert_pos < effective_top_k) {
             for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
-                scaled[j] = scaled[j - 1u];
-                indices[j] = indices[j - 1u];
+                local_vals[j] = local_vals[j - 1u];
+                local_indices[j] = local_indices[j - 1u];
             }
-            scaled[insert_pos] = scaled_val;
-            indices[insert_pos] = i;
+            local_vals[insert_pos] = scaled_val;
+            local_indices[insert_pos] = index;
         }
     }
 
-    if (count == 0u) {
+    shared_counts[tid] = static_cast<ushort>(local_count);
+    shared_fallback_vals[tid] = local_fallback_val;
+    shared_fallback_indices[tid] = local_fallback_idx;
+    shared_fallback_flags[tid] = local_fallback_found ? 1u : 0u;
+
+    uint base = tid * MAX_TOP_K;
+    for (uint i = 0u; i < local_count; ++i) {
+        shared_vals[base + i] = local_vals[i];
+        shared_indices[base + i] = local_indices[i];
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid != 0u) {
+        return;
+    }
+
+    bool fallback_found = false;
+    float fallback_val = -INFINITY;
+    uint fallback_idx = 0u;
+    for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
+        if (shared_fallback_flags[t] == 0u) {
+            continue;
+        }
+        float candidate_val = shared_fallback_vals[t];
+        uint candidate_idx = shared_fallback_indices[t];
+        if (!fallback_found || candidate_val > fallback_val ||
+            (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
+            fallback_found = true;
+            fallback_val = candidate_val;
+            fallback_idx = candidate_idx;
+        }
+    }
+
+    if (!fallback_found) {
+        fallback_idx = 0u;
+    }
+
+    if (skip_sampling) {
         output[0] = fallback_found ? fallback_idx : 0u;
         return;
     }
 
-    float max_val = scaled[0];
+    thread float shortlist_vals[MAX_TOP_K];
+    thread uint shortlist_indices[MAX_TOP_K];
+    uint shortlist_count = 0u;
+
+    for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
+        uint count = shared_counts[t];
+        uint offset = t * MAX_TOP_K;
+        for (uint i = 0u; i < count; ++i) {
+            float val = shared_vals[offset + i];
+            uint idx = shared_indices[offset + i];
+
+            uint insert_pos = 0u;
+            while (insert_pos < shortlist_count && shortlist_vals[insert_pos] > val) {
+                ++insert_pos;
+            }
+
+            if (shortlist_count < effective_top_k) {
+                for (uint j = shortlist_count; j > insert_pos; --j) {
+                    shortlist_vals[j] = shortlist_vals[j - 1];
+                    shortlist_indices[j] = shortlist_indices[j - 1];
+                }
+                shortlist_vals[insert_pos] = val;
+                shortlist_indices[insert_pos] = idx;
+                ++shortlist_count;
+            } else if (insert_pos < effective_top_k) {
+                for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
+                    shortlist_vals[j] = shortlist_vals[j - 1u];
+                    shortlist_indices[j] = shortlist_indices[j - 1u];
+                }
+                shortlist_vals[insert_pos] = val;
+                shortlist_indices[insert_pos] = idx;
+            }
+        }
+    }
+
+    if (shortlist_count == 0u) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    float max_val = shortlist_vals[0];
+    for (uint i = 1u; i < shortlist_count; ++i) {
+        if (shortlist_vals[i] > max_val) {
+            max_val = shortlist_vals[i];
+        }
+    }
+
     float total = 0.0f;
     bool has_positive = false;
-    for (uint i = 0; i < count; ++i) {
-        float val = scaled[i];
-        float exp_val = isfinite(val) ? exp(val - max_val) : 0.0f;
+    for (uint i = 0u; i < shortlist_count; ++i) {
+        float exp_val = exp(shortlist_vals[i] - max_val);
         if (exp_val > 1e10f) {
             exp_val = 1e10f;
         } else if (exp_val < 1e-10f) {
             exp_val = 0.0f;
         }
-        scaled[i] = exp_val;
+        shortlist_vals[i] = exp_val;
         total += exp_val;
         has_positive = has_positive || exp_val > 0.0f;
     }
@@ -132,14 +224,14 @@ kernel void sample_top_k_top_p_f32(
         normalized_top_p = clamp(normalized_top_p, 0.0f, 1.0f);
     }
 
-    uint cutoff = count - 1u;
+    uint cutoff = shortlist_count - 1u;
     if (normalized_top_p <= 0.0f) {
         cutoff = 0u;
     } else if (normalized_top_p < 1.0f) {
         float cumulative = 0.0f;
         float threshold = normalized_top_p * total;
-        for (uint i = 0; i < count; ++i) {
-            cumulative += scaled[i];
+        for (uint i = 0u; i < shortlist_count; ++i) {
+            cumulative += shortlist_vals[i];
             cutoff = i;
             if (cumulative >= threshold || !isfinite(cumulative)) {
                 break;
@@ -148,28 +240,28 @@ kernel void sample_top_k_top_p_f32(
     }
 
     float shortlist_total = 0.0f;
-    for (uint i = 0; i <= cutoff; ++i) {
-        shortlist_total += scaled[i];
+    for (uint i = 0u; i <= cutoff; ++i) {
+        shortlist_total += shortlist_vals[i];
     }
 
     if (shortlist_total <= 0.0f || !isfinite(shortlist_total)) {
-        output[0] = indices[0];
+        output[0] = shortlist_indices[0];
         return;
     }
 
-    for (uint i = 0; i <= cutoff; ++i) {
-        scaled[i] /= shortlist_total;
+    for (uint i = 0u; i <= cutoff; ++i) {
+        shortlist_vals[i] /= shortlist_total;
     }
 
     float random_value = static_cast<float>(params.random_u32) / 4294967295.0f;
     float acc = 0.0f;
-    for (uint i = 0; i <= cutoff; ++i) {
-        acc += scaled[i];
+    for (uint i = 0u; i <= cutoff; ++i) {
+        acc += shortlist_vals[i];
         if (random_value <= acc || !isfinite(acc)) {
-            output[0] = indices[i];
+            output[0] = shortlist_indices[i];
             return;
         }
     }
 
-    output[0] = indices[cutoff];
+    output[0] = shortlist_indices[cutoff];
 }

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -1,0 +1,175 @@
+#include <metal_stdlib>
+using namespace metal;
+
+constant uint MAX_TOP_K = 256;
+
+struct SamplingParams {
+    uint vocab_size;
+    uint top_k;
+    float top_p;
+    float temperature;
+    uint random_u32;
+    uint _padding;
+};
+
+kernel void sample_top_k_top_p_f32(
+    device const float* logits [[buffer(0)]],
+    device uint* output [[buffer(1)]],
+    constant SamplingParams& params [[buffer(2)]],
+    uint tid [[thread_position_in_grid]])
+{
+    if (tid != 0) {
+        return;
+    }
+
+    uint vocab_size = params.vocab_size;
+    if (vocab_size == 0) {
+        output[0] = 0u;
+        return;
+    }
+
+    float temperature = params.temperature;
+    uint requested_top_k = params.top_k;
+
+    uint fallback_idx = 0u;
+    bool fallback_found = false;
+    float fallback_val = -INFINITY;
+    for (uint i = 0; i < vocab_size; ++i) {
+        float val = logits[i];
+        if (isfinite(val) && (!fallback_found || val > fallback_val || (val == fallback_val && i > fallback_idx))) {
+            fallback_idx = i;
+            fallback_val = val;
+            fallback_found = true;
+        }
+    }
+
+    if (!isfinite(temperature) || temperature <= 0.0f) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    if (requested_top_k == 0u) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    uint effective_top_k = requested_top_k;
+    if (effective_top_k < 1u) {
+        effective_top_k = 1u;
+    }
+    if (effective_top_k > vocab_size) {
+        effective_top_k = vocab_size;
+    }
+    if (effective_top_k > MAX_TOP_K) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    thread float scaled[MAX_TOP_K];
+    thread uint indices[MAX_TOP_K];
+    uint count = 0u;
+    float inv_temp = 1.0f / temperature;
+
+    for (uint i = 0; i < vocab_size; ++i) {
+        float scaled_val = logits[i] * inv_temp;
+        if (!isfinite(scaled_val)) {
+            continue;
+        }
+
+        uint insert_pos = 0u;
+        while (insert_pos < count && scaled[insert_pos] > scaled_val) {
+            ++insert_pos;
+        }
+
+        if (count < effective_top_k) {
+            for (uint j = count; j > insert_pos; --j) {
+                scaled[j] = scaled[j - 1];
+                indices[j] = indices[j - 1];
+            }
+            scaled[insert_pos] = scaled_val;
+            indices[insert_pos] = i;
+            ++count;
+        } else if (insert_pos < effective_top_k) {
+            for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
+                scaled[j] = scaled[j - 1u];
+                indices[j] = indices[j - 1u];
+            }
+            scaled[insert_pos] = scaled_val;
+            indices[insert_pos] = i;
+        }
+    }
+
+    if (count == 0u) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    float max_val = scaled[0];
+    float total = 0.0f;
+    bool has_positive = false;
+    for (uint i = 0; i < count; ++i) {
+        float val = scaled[i];
+        float exp_val = isfinite(val) ? exp(val - max_val) : 0.0f;
+        if (exp_val > 1e10f) {
+            exp_val = 1e10f;
+        } else if (exp_val < 1e-10f) {
+            exp_val = 0.0f;
+        }
+        scaled[i] = exp_val;
+        total += exp_val;
+        has_positive = has_positive || exp_val > 0.0f;
+    }
+
+    if (!has_positive || total <= 0.0f || !isfinite(total)) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    float normalized_top_p = params.top_p;
+    if (!isfinite(normalized_top_p)) {
+        normalized_top_p = 1.0f;
+    } else {
+        normalized_top_p = clamp(normalized_top_p, 0.0f, 1.0f);
+    }
+
+    uint cutoff = count - 1u;
+    if (normalized_top_p <= 0.0f) {
+        cutoff = 0u;
+    } else if (normalized_top_p < 1.0f) {
+        float cumulative = 0.0f;
+        float threshold = normalized_top_p * total;
+        for (uint i = 0; i < count; ++i) {
+            cumulative += scaled[i];
+            cutoff = i;
+            if (cumulative >= threshold || !isfinite(cumulative)) {
+                break;
+            }
+        }
+    }
+
+    float shortlist_total = 0.0f;
+    for (uint i = 0; i <= cutoff; ++i) {
+        shortlist_total += scaled[i];
+    }
+
+    if (shortlist_total <= 0.0f || !isfinite(shortlist_total)) {
+        output[0] = indices[0];
+        return;
+    }
+
+    for (uint i = 0; i <= cutoff; ++i) {
+        scaled[i] /= shortlist_total;
+    }
+
+    float random_value = static_cast<float>(params.random_u32) / 4294967295.0f;
+    float acc = 0.0f;
+    for (uint i = 0; i <= cutoff; ++i) {
+        acc += scaled[i];
+        if (random_value <= acc || !isfinite(acc)) {
+            output[0] = indices[i];
+            return;
+        }
+    }
+
+    output[0] = indices[cutoff];
+}

--- a/src/metallic/kernels/sampling/kernel.metal
+++ b/src/metallic/kernels/sampling/kernel.metal
@@ -18,6 +18,33 @@ struct SamplingParams {
     uint _padding1;
 };
 
+void swap_local(thread float* a, thread float* b, thread uint* a_idx, thread uint* b_idx) {
+    float temp = *a;
+    *a = *b;
+    *b = temp;
+    uint temp_idx = *a_idx;
+    *a_idx = *b_idx;
+    *b_idx = temp_idx;
+}
+
+void sort_16(thread float* vals, thread uint* indices) {
+    // Bitonic sorting network for 16 elements, descending
+    #define SWAP(i, j) if (vals[i] < vals[j]) { swap_local(&vals[i], &vals[j], &indices[i], &indices[j]); }
+
+    SWAP(0, 1); SWAP(2, 3); SWAP(4, 5); SWAP(6, 7); SWAP(8, 9); SWAP(10, 11); SWAP(12, 13); SWAP(14, 15);
+    SWAP(0, 2); SWAP(1, 3); SWAP(4, 6); SWAP(5, 7); SWAP(8, 10); SWAP(9, 11); SWAP(12, 14); SWAP(13, 15);
+    SWAP(0, 4); SWAP(1, 5); SWAP(2, 6); SWAP(3, 7); SWAP(8, 12); SWAP(9, 13); SWAP(10, 14); SWAP(11, 15);
+    SWAP(0, 8); SWAP(1, 9); SWAP(2, 10); SWAP(3, 11); SWAP(4, 12); SWAP(5, 13); SWAP(6, 14); SWAP(7, 15);
+
+    SWAP(0, 1); SWAP(2, 3); SWAP(4, 5); SWAP(6, 7); SWAP(8, 9); SWAP(10, 11); SWAP(12, 13); SWAP(14, 15);
+    SWAP(2, 4); SWAP(3, 5); SWAP(6, 8); SWAP(7, 9); SWAP(10, 12); SWAP(11, 13);
+    SWAP(1, 2); SWAP(3, 4); SWAP(5, 6); SWAP(7, 8); SWAP(9, 10); SWAP(11, 12);
+    SWAP(0, 1); SWAP(2, 3); SWAP(4, 5); SWAP(6, 7); SWAP(8, 9); SWAP(10, 11); SWAP(12, 13); SWAP(14, 15);
+
+    #undef SWAP
+}
+
+
 kernel void sample_top_k_top_p_stage1_f32(
     device const float* logits [[buffer(0)]],
     device uint* unused_output [[buffer(1)]],
@@ -76,14 +103,244 @@ kernel void sample_top_k_top_p_stage1_f32(
         skip_sampling = true;
     }
 
-    uint local_capacity = min(effective_top_k, TOKENS_PER_THREAD);
+    thread float local_vals[TOKENS_PER_THREAD];
+    thread uint local_indices[TOKENS_PER_THREAD];
+    uint local_count = 0u;
+    bool local_fallback_found = false;
+    float local_fallback_val = -INFINITY;
+    uint local_fallback_idx = 0u;
+
+    float inv_temp = skip_sampling ? 0.0f : 1.0f / temperature;
+
+    for (uint step = 0u; step < TOKENS_PER_THREAD; ++step) {
+        uint index = start_index + step * THREADGROUP_SIZE + tid;
+        if (index >= vocab_size) {
+            local_vals[step] = -INFINITY;
+            local_indices[step] = 0;
+            continue;
+        }
+
+        float logit = float(logits[index]);
+        if (isfinite(logit) && (!local_fallback_found || logit > local_fallback_val ||
+                                (logit == local_fallback_val && index > local_fallback_idx))) {
+            local_fallback_found = true;
+            local_fallback_val = logit;
+            local_fallback_idx = index;
+        }
+
+        if (skip_sampling) {
+            local_vals[step] = -INFINITY;
+            local_indices[step] = 0;
+            continue;
+        }
+
+        float scaled_val = logit * inv_temp;
+        if (!isfinite(scaled_val)) {
+            local_vals[step] = -INFINITY;
+            local_indices[step] = 0;
+            continue;
+        }
+        local_vals[step] = scaled_val;
+        local_indices[step] = index;
+    }
+
+    sort_16(local_vals, local_indices);
 
     threadgroup float shared_vals[THREADGROUP_SIZE * TOKENS_PER_THREAD];
     threadgroup uint shared_indices[THREADGROUP_SIZE * TOKENS_PER_THREAD];
     threadgroup uint shared_counts[THREADGROUP_SIZE];
+    threadgroup uint shared_positions[THREADGROUP_SIZE];
     threadgroup float shared_fallback_vals[THREADGROUP_SIZE];
     threadgroup uint shared_fallback_indices[THREADGROUP_SIZE];
     threadgroup uint shared_fallback_flags[THREADGROUP_SIZE];
+    threadgroup float candidate_vals[THREADGROUP_SIZE];
+    threadgroup uint candidate_indices[THREADGROUP_SIZE];
+    threadgroup uint candidate_owners[THREADGROUP_SIZE];
+    threadgroup uint selection_active;
+
+    shared_counts[tid] = min((uint)TOKENS_PER_THREAD, effective_top_k);
+    shared_positions[tid] = 0u;
+    shared_fallback_vals[tid] = local_fallback_val;
+    shared_fallback_indices[tid] = local_fallback_idx;
+    shared_fallback_flags[tid] = local_fallback_found ? 1u : 0u;
+
+    uint shared_base = tid * TOKENS_PER_THREAD;
+    for (uint i = 0u; i < TOKENS_PER_THREAD; ++i) {
+        shared_vals[shared_base + i] = local_vals[i];
+        shared_indices[shared_base + i] = local_indices[i];
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    bool fallback_found = false;
+    float fallback_val = -INFINITY;
+    uint fallback_idx = 0u;
+    if (shared_fallback_flags[tid] != 0u) {
+        float candidate_val = shared_fallback_vals[tid];
+        uint candidate_idx = shared_fallback_indices[tid];
+        if (!fallback_found || candidate_val > fallback_val ||
+            (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
+            fallback_found = true;
+            fallback_val = candidate_val;
+            fallback_idx = candidate_idx;
+        }
+    }
+
+    threadgroup float fallback_vals_shared[THREADGROUP_SIZE];
+    threadgroup uint fallback_indices_shared[THREADGROUP_SIZE];
+    threadgroup uint fallback_flags_shared[THREADGROUP_SIZE];
+
+    fallback_vals_shared[tid] = fallback_val;
+    fallback_indices_shared[tid] = fallback_idx;
+    fallback_flags_shared[tid] = fallback_found ? 1u : 0u;
+
+    for (uint offset = THREADGROUP_SIZE / 2u; offset > 0u; offset >>= 1u) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tid < offset) {
+            float other_val = fallback_vals_shared[tid + offset];
+            uint other_idx = fallback_indices_shared[tid + offset];
+            uint other_flag = fallback_flags_shared[tid + offset];
+            bool take_other = other_flag != 0u &&
+                (fallback_flags_shared[tid] == 0u || other_val > fallback_vals_shared[tid] ||
+                 (other_val == fallback_vals_shared[tid] && other_idx > fallback_indices_shared[tid]));
+            if (take_other) {
+                fallback_vals_shared[tid] = other_val;
+                fallback_indices_shared[tid] = other_idx;
+                fallback_flags_shared[tid] = 1u;
+            }
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    uint shortlist_count = 0u;
+    if (!skip_sampling) {
+        for (uint selection = 0u; selection < effective_top_k; ++selection) {
+            if (tid == 0u) {
+                selection_active = 1u;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            uint pos = shared_positions[tid];
+            bool has_candidate = pos < shared_counts[tid];
+            if (has_candidate) {
+                uint offset = tid * TOKENS_PER_THREAD + pos;
+                candidate_vals[tid] = shared_vals[offset];
+                candidate_indices[tid] = shared_indices[offset];
+                candidate_owners[tid] = tid;
+            } else {
+                candidate_vals[tid] = -INFINITY;
+                candidate_indices[tid] = 0u;
+                candidate_owners[tid] = tid;
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (uint offset = THREADGROUP_SIZE / 2u; offset > 0u; offset >>= 1u) {
+                if (tid < offset) {
+                    float other_val = candidate_vals[tid + offset];
+                    uint other_idx = candidate_indices[tid + offset];
+                    uint other_owner = candidate_owners[tid + offset];
+                    bool take_other = other_val > candidate_vals[tid] ||
+                        (other_val == candidate_vals[tid] && other_idx > candidate_indices[tid]);
+                    if (take_other) {
+                        candidate_vals[tid] = other_val;
+                        candidate_indices[tid] = other_idx;
+                        candidate_owners[tid] = other_owner;
+                    }
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+            }
+
+            if (tid == 0u) {
+                float best_val = candidate_vals[0];
+                uint best_idx = candidate_indices[0];
+                if (!isfinite(best_val)) {
+                    selection_active = 0u;
+                } else {
+                    uint winner_tid = candidate_owners[0];
+                    uint base = threadgroup_index * effective_top_k + shortlist_count;
+                    partial_vals[base] = best_val;
+                    partial_indices[base] = best_idx;
+                    ++shortlist_count;
+
+                    shared_positions[winner_tid] += 1u;
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (selection_active == 0u) {
+                break;
+            }
+        }
+    }
+
+    if (tid == 0u) {
+        partial_counts[threadgroup_index] = shortlist_count;
+        fallback_vals[threadgroup_index] = fallback_vals_shared[0];
+        fallback_indices[threadgroup_index] = fallback_indices_shared[0];
+        fallback_flags[threadgroup_index] = fallback_flags_shared[0];
+    }
+}
+
+kernel void sample_top_k_top_p_stage1_f16(
+    device const half* logits [[buffer(0)]],
+    device uint* unused_output [[buffer(1)]],
+    device float* partial_vals [[buffer(2)]],
+    device uint* partial_indices [[buffer(3)]],
+    device uint* partial_counts [[buffer(4)]],
+    device float* fallback_vals [[buffer(5)]],
+    device uint* fallback_indices [[buffer(6)]],
+    device uint* fallback_flags [[buffer(7)]],
+    constant SamplingParams& params [[buffer(9)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]])
+{
+    (void)unused_output;
+
+    uint vocab_size = params.vocab_size;
+    if (vocab_size == 0u) {
+        return;
+    }
+
+    uint threadgroup_index = tg_pos.x;
+    uint threadgroup_count = max(params.threadgroup_count, 1u);
+    if (threadgroup_index >= threadgroup_count) {
+        return;
+    }
+
+    uint start_index = threadgroup_index * THREADGROUP_TOKENS;
+    if (start_index >= vocab_size) {
+        if (tid == 0u) {
+            partial_counts[threadgroup_index] = 0u;
+            fallback_flags[threadgroup_index] = 0u;
+        }
+        return;
+    }
+
+    uint requested_top_k = params.top_k;
+    float temperature = params.temperature;
+
+    bool skip_sampling = false;
+    if (!isfinite(temperature) || temperature <= 0.0f) {
+        skip_sampling = true;
+    }
+    if (requested_top_k == 0u) {
+        skip_sampling = true;
+    }
+
+    uint effective_top_k = requested_top_k;
+    if (effective_top_k < 1u) {
+        effective_top_k = 1u;
+    }
+    if (effective_top_k > vocab_size) {
+        effective_top_k = vocab_size;
+    }
+    if (effective_top_k > MAX_TOP_K) {
+        effective_top_k = MAX_TOP_K;
+        skip_sampling = true;
+    }
 
     thread float local_vals[TOKENS_PER_THREAD];
     thread uint local_indices[TOKENS_PER_THREAD];
@@ -97,10 +354,12 @@ kernel void sample_top_k_top_p_stage1_f32(
     for (uint step = 0u; step < TOKENS_PER_THREAD; ++step) {
         uint index = start_index + step * THREADGROUP_SIZE + tid;
         if (index >= vocab_size) {
-            break;
+            local_vals[step] = -INFINITY;
+            local_indices[step] = 0;
+            continue;
         }
 
-        float logit = logits[index];
+        float logit = float(logits[index]);
         if (isfinite(logit) && (!local_fallback_found || logit > local_fallback_val ||
                                 (logit == local_fallback_val && index > local_fallback_idx))) {
             local_fallback_found = true;
@@ -109,119 +368,348 @@ kernel void sample_top_k_top_p_stage1_f32(
         }
 
         if (skip_sampling) {
+            local_vals[step] = -INFINITY;
+            local_indices[step] = 0;
             continue;
         }
 
         float scaled_val = logit * inv_temp;
         if (!isfinite(scaled_val)) {
+            local_vals[step] = -INFINITY;
+            local_indices[step] = 0;
             continue;
         }
-
-        uint insert_pos = 0u;
-        while (insert_pos < local_count && local_vals[insert_pos] > scaled_val) {
-            ++insert_pos;
-        }
-
-        if (local_count < local_capacity) {
-            for (uint j = local_count; j > insert_pos; --j) {
-                local_vals[j] = local_vals[j - 1u];
-                local_indices[j] = local_indices[j - 1u];
-            }
-            local_vals[insert_pos] = scaled_val;
-            local_indices[insert_pos] = index;
-            ++local_count;
-        } else if (insert_pos < local_capacity) {
-            for (uint j = local_capacity - 1u; j > insert_pos; --j) {
-                local_vals[j] = local_vals[j - 1u];
-                local_indices[j] = local_indices[j - 1u];
-            }
-            local_vals[insert_pos] = scaled_val;
-            local_indices[insert_pos] = index;
-        }
+        local_vals[step] = scaled_val;
+        local_indices[step] = index;
     }
 
-    shared_counts[tid] = local_count;
+    sort_16(local_vals, local_indices);
+
+    threadgroup float shared_vals[THREADGROUP_SIZE * TOKENS_PER_THREAD];
+    threadgroup uint shared_indices[THREADGROUP_SIZE * TOKENS_PER_THREAD];
+    threadgroup uint shared_counts[THREADGROUP_SIZE];
+    threadgroup uint shared_positions[THREADGROUP_SIZE];
+    threadgroup float shared_fallback_vals[THREADGROUP_SIZE];
+    threadgroup uint shared_fallback_indices[THREADGROUP_SIZE];
+    threadgroup uint shared_fallback_flags[THREADGROUP_SIZE];
+    threadgroup float candidate_vals[THREADGROUP_SIZE];
+    threadgroup uint candidate_indices[THREADGROUP_SIZE];
+    threadgroup uint candidate_owners[THREADGROUP_SIZE];
+    threadgroup uint selection_active;
+
+    shared_counts[tid] = min((uint)TOKENS_PER_THREAD, effective_top_k);
+    shared_positions[tid] = 0u;
     shared_fallback_vals[tid] = local_fallback_val;
     shared_fallback_indices[tid] = local_fallback_idx;
     shared_fallback_flags[tid] = local_fallback_found ? 1u : 0u;
 
     uint shared_base = tid * TOKENS_PER_THREAD;
-    for (uint i = 0u; i < local_count; ++i) {
+    for (uint i = 0u; i < TOKENS_PER_THREAD; ++i) {
         shared_vals[shared_base + i] = local_vals[i];
         shared_indices[shared_base + i] = local_indices[i];
     }
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (tid == 0u) {
-        bool fallback_found = false;
-        float fallback_val = -INFINITY;
-        uint fallback_idx = 0u;
-        for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
-            if (shared_fallback_flags[t] == 0u) {
-                continue;
-            }
-            float candidate_val = shared_fallback_vals[t];
-            uint candidate_idx = shared_fallback_indices[t];
-            if (!fallback_found || candidate_val > fallback_val ||
-                (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
-                fallback_found = true;
-                fallback_val = candidate_val;
-                fallback_idx = candidate_idx;
+    bool fallback_found = false;
+    float fallback_val = -INFINITY;
+    uint fallback_idx = 0u;
+    if (shared_fallback_flags[tid] != 0u) {
+        float candidate_val = shared_fallback_vals[tid];
+        uint candidate_idx = shared_fallback_indices[tid];
+        if (!fallback_found || candidate_val > fallback_val ||
+            (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
+            fallback_found = true;
+            fallback_val = candidate_val;
+            fallback_idx = candidate_idx;
+        }
+    }
+
+    threadgroup float fallback_vals_shared[THREADGROUP_SIZE];
+    threadgroup uint fallback_indices_shared[THREADGROUP_SIZE];
+    threadgroup uint fallback_flags_shared[THREADGROUP_SIZE];
+
+    fallback_vals_shared[tid] = fallback_val;
+    fallback_indices_shared[tid] = fallback_idx;
+    fallback_flags_shared[tid] = fallback_found ? 1u : 0u;
+
+    for (uint offset = THREADGROUP_SIZE / 2u; offset > 0u; offset >>= 1u) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tid < offset) {
+            float other_val = fallback_vals_shared[tid + offset];
+            uint other_idx = fallback_indices_shared[tid + offset];
+            uint other_flag = fallback_flags_shared[tid + offset];
+            bool take_other = other_flag != 0u &&
+                (fallback_flags_shared[tid] == 0u || other_val > fallback_vals_shared[tid] ||
+                 (other_val == fallback_vals_shared[tid] && other_idx > fallback_indices_shared[tid]));
+            if (take_other) {
+                fallback_vals_shared[tid] = other_val;
+                fallback_indices_shared[tid] = other_idx;
+                fallback_flags_shared[tid] = 1u;
             }
         }
+    }
 
-        thread float shortlist_vals[MAX_TOP_K];
-        thread uint shortlist_indices[MAX_TOP_K];
-        uint shortlist_count = 0u;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        if (!skip_sampling) {
-            for (uint t = 0u; t < THREADGROUP_SIZE; ++t) {
-                uint count = min(shared_counts[t], local_capacity);
-                uint offset = t * TOKENS_PER_THREAD;
-                for (uint i = 0u; i < count; ++i) {
-                    float val = shared_vals[offset + i];
-                    uint idx = shared_indices[offset + i];
+    uint shortlist_count = 0u;
+    if (!skip_sampling) {
+        for (uint selection = 0u; selection < effective_top_k; ++selection) {
+            if (tid == 0u) {
+                selection_active = 1u;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
 
-                    uint insert_pos = 0u;
-                    while (insert_pos < shortlist_count && shortlist_vals[insert_pos] > val) {
-                        ++insert_pos;
-                    }
+            uint pos = shared_positions[tid];
+            bool has_candidate = pos < shared_counts[tid];
+            if (has_candidate) {
+                uint offset = tid * TOKENS_PER_THREAD + pos;
+                candidate_vals[tid] = shared_vals[offset];
+                candidate_indices[tid] = shared_indices[offset];
+                candidate_owners[tid] = tid;
+            } else {
+                candidate_vals[tid] = -INFINITY;
+                candidate_indices[tid] = 0u;
+                candidate_owners[tid] = tid;
+            }
 
-                    if (shortlist_count < effective_top_k) {
-                        for (uint j = shortlist_count; j > insert_pos; --j) {
-                            shortlist_vals[j] = shortlist_vals[j - 1u];
-                            shortlist_indices[j] = shortlist_indices[j - 1u];
-                        }
-                        shortlist_vals[insert_pos] = val;
-                        shortlist_indices[insert_pos] = idx;
-                        ++shortlist_count;
-                    } else if (insert_pos < effective_top_k) {
-                        for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
-                            shortlist_vals[j] = shortlist_vals[j - 1u];
-                            shortlist_indices[j] = shortlist_indices[j - 1u];
-                        }
-                        shortlist_vals[insert_pos] = val;
-                        shortlist_indices[insert_pos] = idx;
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (uint offset = THREADGROUP_SIZE / 2u; offset > 0u; offset >>= 1u) {
+                if (tid < offset) {
+                    float other_val = candidate_vals[tid + offset];
+                    uint other_idx = candidate_indices[tid + offset];
+                    uint other_owner = candidate_owners[tid + offset];
+                    bool take_other = other_val > candidate_vals[tid] ||
+                        (other_val == candidate_vals[tid] && other_idx > candidate_indices[tid]);
+                    if (take_other) {
+                        candidate_vals[tid] = other_val;
+                        candidate_indices[tid] = other_idx;
+                        candidate_owners[tid] = other_owner;
                     }
                 }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+            }
+
+            if (tid == 0u) {
+                float best_val = candidate_vals[0];
+                uint best_idx = candidate_indices[0];
+                if (!isfinite(best_val)) {
+                    selection_active = 0u;
+                } else {
+                    uint winner_tid = candidate_owners[0];
+                    uint base = threadgroup_index * effective_top_k + shortlist_count;
+                    partial_vals[base] = best_val;
+                    partial_indices[base] = best_idx;
+                    ++shortlist_count;
+
+                    shared_positions[winner_tid] += 1u;
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (selection_active == 0u) {
+                break;
             }
         }
+    }
 
-        uint base = threadgroup_index * effective_top_k;
-        for (uint i = 0u; i < shortlist_count; ++i) {
-            partial_vals[base + i] = shortlist_vals[i];
-            partial_indices[base + i] = shortlist_indices[i];
-        }
+    if (tid == 0u) {
         partial_counts[threadgroup_index] = shortlist_count;
-        fallback_vals[threadgroup_index] = fallback_val;
-        fallback_indices[threadgroup_index] = fallback_idx;
-        fallback_flags[threadgroup_index] = fallback_found ? 1u : 0u;
+        fallback_vals[threadgroup_index] = fallback_vals_shared[0];
+        fallback_indices[threadgroup_index] = fallback_indices_shared[0];
+        fallback_flags[threadgroup_index] = fallback_flags_shared[0];
     }
 }
 
 kernel void sample_top_k_top_p_finalize_f32(
     device const float* logits [[buffer(0)]],
+    device uint* output [[buffer(1)]],
+    device const float* partial_vals [[buffer(2)]],
+    device const uint* partial_indices [[buffer(3)]],
+    device const uint* partial_counts [[buffer(4)]],
+    device const float* fallback_vals [[buffer(5)]],
+    device const uint* fallback_indices [[buffer(6)]],
+    device const uint* fallback_flags [[buffer(7)]],
+    constant SamplingParams& params [[buffer(9)]],
+    uint tid [[thread_index_in_threadgroup]])
+{
+    (void)logits;
+
+    if (tid != 0u) {
+        return;
+    }
+
+    uint vocab_size = params.vocab_size;
+    if (vocab_size == 0u) {
+        output[0] = 0u;
+        return;
+    }
+
+    uint threadgroup_count = max(params.threadgroup_count, 1u);
+    uint requested_top_k = params.top_k;
+    float temperature = params.temperature;
+
+    bool skip_sampling = false;
+    if (!isfinite(temperature) || temperature <= 0.0f) {
+        skip_sampling = true;
+    }
+    if (requested_top_k == 0u) {
+        skip_sampling = true;
+    }
+
+    uint effective_top_k = requested_top_k;
+    if (effective_top_k < 1u) {
+        effective_top_k = 1u;
+    }
+    if (effective_top_k > vocab_size) {
+        effective_top_k = vocab_size;
+    }
+    if (effective_top_k > MAX_TOP_K) {
+        effective_top_k = MAX_TOP_K;
+        skip_sampling = true;
+    }
+
+    bool fallback_found = false;
+    float fallback_val = -INFINITY;
+    uint fallback_idx = 0u;
+    for (uint group = 0u; group < threadgroup_count; ++group) {
+        if (fallback_flags[group] == 0u) {
+            continue;
+        }
+        float candidate_val = fallback_vals[group];
+        uint candidate_idx = fallback_indices[group];
+        if (!fallback_found || candidate_val > fallback_val ||
+            (candidate_val == fallback_val && candidate_idx > fallback_idx)) {
+            fallback_found = true;
+            fallback_val = candidate_val;
+            fallback_idx = candidate_idx;
+        }
+    }
+
+    if (skip_sampling) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    thread float shortlist_vals[MAX_TOP_K];
+    thread uint shortlist_indices[MAX_TOP_K];
+    uint shortlist_count = 0u;
+
+    for (uint group = 0u; group < threadgroup_count; ++group) {
+        uint count = min(partial_counts[group], effective_top_k);
+        uint base = group * effective_top_k;
+        for (uint i = 0u; i < count; ++i) {
+            float val = partial_vals[base + i];
+            uint idx = partial_indices[base + i];
+
+            uint insert_pos = 0u;
+            while (insert_pos < shortlist_count && shortlist_vals[insert_pos] > val) {
+                ++insert_pos;
+            }
+
+            if (shortlist_count < effective_top_k) {
+                for (uint j = shortlist_count; j > insert_pos; --j) {
+                    shortlist_vals[j] = shortlist_vals[j - 1u];
+                    shortlist_indices[j] = shortlist_indices[j - 1u];
+                }
+                shortlist_vals[insert_pos] = val;
+                shortlist_indices[insert_pos] = idx;
+                ++shortlist_count;
+            } else if (insert_pos < effective_top_k) {
+                for (uint j = effective_top_k - 1u; j > insert_pos; --j) {
+                    shortlist_vals[j] = shortlist_vals[j - 1u];
+                    shortlist_indices[j] = shortlist_indices[j - 1u];
+                }
+                shortlist_vals[insert_pos] = val;
+                shortlist_indices[insert_pos] = idx;
+            }
+        }
+    }
+
+    if (shortlist_count == 0u) {
+        output[0] = fallback_found ? fallback_idx : 0u;
+        return;
+    }
+
+    float max_val = shortlist_vals[0];
+    for (uint i = 1u; i < shortlist_count; ++i) {
+        if (shortlist_vals[i] > max_val) {
+            max_val = shortlist_vals[i];
+        }
+    }
+
+    float total = 0.0f;
+    bool has_positive = false;
+    for (uint i = 0u; i < shortlist_count; ++i) {
+        float exp_val = exp(shortlist_vals[i] - max_val);
+        if (exp_val > 1e10f) {
+            exp_val = 1e10f;
+        } else if (exp_val < 1e-10f) {
+            exp_val = 0.0f;
+        }
+        shortlist_vals[i] = exp_val;
+        total += exp_val;
+        has_positive = has_positive || exp_val > 0.0f;
+    }
+
+    if (!has_positive || total <= 0.0f || !isfinite(total)) {
+        output[0] = fallback_found ? fallback_idx : shortlist_indices[0];
+        return;
+    }
+
+    float normalized_top_p = params.top_p;
+    if (!isfinite(normalized_top_p)) {
+        normalized_top_p = 1.0f;
+    } else {
+        normalized_top_p = clamp(normalized_top_p, 0.0f, 1.0f);
+    }
+
+    uint cutoff = shortlist_count - 1u;
+    if (normalized_top_p <= 0.0f) {
+        cutoff = 0u;
+    } else if (normalized_top_p < 1.0f) {
+        float cumulative = 0.0f;
+        float threshold = normalized_top_p * total;
+        for (uint i = 0u; i < shortlist_count; ++i) {
+            cumulative += shortlist_vals[i];
+            cutoff = i;
+            if (cumulative >= threshold || !isfinite(cumulative)) {
+                break;
+            }
+        }
+    }
+
+    float shortlist_total = 0.0f;
+    for (uint i = 0u; i <= cutoff; ++i) {
+        shortlist_total += shortlist_vals[i];
+    }
+
+    if (shortlist_total <= 0.0f || !isfinite(shortlist_total)) {
+        output[0] = shortlist_indices[0];
+        return;
+    }
+
+    for (uint i = 0u; i <= cutoff; ++i) {
+        shortlist_vals[i] /= shortlist_total;
+    }
+
+    float random_value = static_cast<float>(params.random_u32) / 4294967295.0f;
+    float acc = 0.0f;
+    for (uint i = 0u; i <= cutoff; ++i) {
+        acc += shortlist_vals[i];
+        if (random_value <= acc || !isfinite(acc)) {
+            output[0] = shortlist_indices[i];
+            return;
+        }
+    }
+
+    output[0] = shortlist_indices[cutoff];
+}
+
+kernel void sample_top_k_top_p_finalize_f16(
+    device const half* logits [[buffer(0)]],
     device uint* output [[buffer(1)]],
     device const float* partial_vals [[buffer(2)]],
     device const uint* partial_indices [[buffer(3)]],

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 /// Maximum supported top-k for the GPU sampling kernel. Larger requests fall
 /// back to the CPU implementation to avoid excessive per-thread stack usage.
 pub const MAX_TOP_K: usize = 256;

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -1,3 +1,7 @@
+use super::*;
+
+use crate::metallic::{TensorElement, tensor::RetainedBuffer};
+
 /// Maximum supported top-k for the GPU sampling kernel. Larger requests fall
 /// back to the CPU implementation to avoid excessive per-thread stack usage.
 pub const MAX_TOP_K: usize = 256;
@@ -11,4 +15,79 @@ pub struct SamplingParams {
     pub temperature: f32,
     pub random_u32: u32,
     pub _padding: u32,
+}
+
+pub struct SampleTopKTopPOp;
+
+struct SampleTopKTopP<T: TensorElement> {
+    logits: Tensor<T>,
+    result: RetainedBuffer,
+    params: SamplingParams,
+    pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+}
+
+impl KernelInvocable for SampleTopKTopPOp {
+    type Args<'a, T: TensorElement> = (Tensor<T>, SamplingParams, RetainedBuffer);
+
+    fn function_id() -> Option<KernelFunction> {
+        Some(KernelFunction::SampleTopKTopP)
+    }
+
+    fn new<'a, T: TensorElement>(
+        ctx: &mut Context<T>,
+        args: Self::Args<'a, T>,
+        pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
+        _cache: Option<&mut ResourceCache>,
+    ) -> Result<(Box<dyn Operation>, Tensor<T>), MetalError> {
+        if T::DTYPE != Dtype::F32 {
+            return Err(MetalError::OperationNotSupported(
+                "top-k/top-p sampling kernel only supports f32 logits".to_string(),
+            ));
+        }
+
+        let (logits, params, result) = args;
+        ctx.prepare_tensors_for_active_cmd(&[&logits])?;
+
+        let output = logits.clone();
+        let op = SampleTopKTopP {
+            logits,
+            result,
+            params,
+            pipeline: pipeline.expect("Kernel Module should supply a pipeline"),
+        };
+
+        Ok((Box::new(op), output))
+    }
+}
+
+impl<T: TensorElement> Operation for SampleTopKTopP<T> {
+    fn encode(
+        &self,
+        command_buffer: &Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+        _cache: &mut ResourceCache,
+    ) -> Result<(), MetalError> {
+        let encoder = command_buffer
+            .computeCommandEncoder()
+            .ok_or(MetalError::ComputeEncoderCreationFailed)?;
+
+        set_compute_pipeline_state(&encoder, &self.pipeline);
+        set_buffer(&encoder, 0, &self.logits.buf, self.logits.offset);
+        set_buffer(&encoder, 1, &self.result, 0);
+        set_bytes(&encoder, 2, &self.params);
+
+        let grid_size = MTLSize {
+            width: 1,
+            height: 1,
+            depth: 1,
+        };
+        let threadgroup_size = MTLSize {
+            width: 1,
+            height: 1,
+            depth: 1,
+        };
+
+        dispatch_threads(&encoder, grid_size, threadgroup_size);
+        encoder.endEncoding();
+        Ok(())
+    }
 }

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -1,0 +1,16 @@
+use super::*;
+
+/// Maximum supported top-k for the GPU sampling kernel. Larger requests fall
+/// back to the CPU implementation to avoid excessive per-thread stack usage.
+pub const MAX_TOP_K: usize = 256;
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SamplingParams {
+    pub vocab_size: u32,
+    pub top_k: u32,
+    pub top_p: f32,
+    pub temperature: f32,
+    pub random_u32: u32,
+    pub _padding: u32,
+}

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -51,7 +51,6 @@ struct SampleTopKTopP<T: TensorElement> {
     stage1_pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
     stage2_pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
     dispatch_timing: Option<SamplingDispatchTiming>,
-    effective_top_k: usize,
     threadgroup_count: usize,
 }
 
@@ -173,7 +172,6 @@ impl KernelInvocable for SampleTopKTopPOp {
             stage1_pipeline,
             stage2_pipeline,
             dispatch_timing,
-            effective_top_k,
             threadgroup_count,
         };
 

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -1,15 +1,18 @@
 use super::*;
 
 use crate::metallic::instrumentation::{KernelDispatchKind, SamplingDispatchTiming};
+use crate::metallic::sampling::effective_top_k;
 use crate::metallic::{TensorElement, tensor::RetainedBuffer};
 use objc2::msg_send;
 use objc2::runtime::{Bool, ProtocolObject};
 use objc2_foundation::NSUInteger;
-use objc2_metal::MTLCounterSampleBuffer;
+use objc2_metal::{MTLCounterSampleBuffer, MTLResourceOptions};
+use std::mem;
+use std::ptr;
 
 /// Number of threads launched for the sampling reduction kernel. This must match
 /// `THREADGROUP_SIZE` in `kernel.metal`.
-const THREADGROUP_SIZE: usize = 8;
+const THREADGROUP_SIZE: usize = 32;
 
 /// Maximum supported top-k for the GPU sampling kernel. Larger requests fall
 /// back to the CPU implementation to avoid excessive per-thread stack usage.
@@ -20,10 +23,12 @@ pub const MAX_TOP_K: usize = 256;
 pub struct SamplingParams {
     pub vocab_size: u32,
     pub top_k: u32,
+    pub random_u32: u32,
+    pub threadgroup_count: u32,
     pub top_p: f32,
     pub temperature: f32,
-    pub random_u32: u32,
-    pub _padding: u32,
+    pub _padding0: u32,
+    pub _padding1: u32,
 }
 
 pub struct SampleTopKTopPOp;
@@ -31,9 +36,18 @@ pub struct SampleTopKTopPOp;
 struct SampleTopKTopP<T: TensorElement> {
     logits: Tensor<T>,
     result: RetainedBuffer,
+    partial_vals: RetainedBuffer,
+    partial_indices: RetainedBuffer,
+    partial_counts: RetainedBuffer,
+    fallback_vals: RetainedBuffer,
+    fallback_indices: RetainedBuffer,
+    fallback_flags: RetainedBuffer,
+    completion_counter: RetainedBuffer,
     params: SamplingParams,
     pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
     dispatch_timing: Option<SamplingDispatchTiming>,
+    effective_top_k: usize,
+    threadgroup_count: usize,
 }
 
 impl KernelInvocable for SampleTopKTopPOp {
@@ -55,7 +69,7 @@ impl KernelInvocable for SampleTopKTopPOp {
             ));
         }
 
-        let (logits, params, result) = args;
+        let (logits, raw_params, result) = args;
         ctx.prepare_tensors_for_active_cmd(&[&logits])?;
 
         let dispatch_timing = {
@@ -66,13 +80,102 @@ impl KernelInvocable for SampleTopKTopPOp {
             ctx.register_sampling_dispatch(&command_buffer).timing().cloned()
         };
 
+        let vocab_size = raw_params.vocab_size as usize;
+        let threadgroup_count = ((vocab_size + THREADGROUP_SIZE - 1) / THREADGROUP_SIZE).max(1);
+        if threadgroup_count > u32::MAX as usize {
+            return Err(MetalError::OperationNotSupported(
+                "sampling kernel threadgroup count exceeds u32::MAX".to_string(),
+            ));
+        }
+
+        let effective_top_k = effective_top_k(raw_params.top_k as usize, vocab_size).min(MAX_TOP_K);
+
+        let partial_len = threadgroup_count
+            .checked_mul(effective_top_k)
+            .ok_or_else(|| MetalError::OperationNotSupported("sampling kernel partial buffer size overflow".to_string()))?;
+
+        let partial_vals_bytes = partial_len
+            .checked_mul(mem::size_of::<f32>())
+            .ok_or_else(|| MetalError::OperationNotSupported("sampling kernel partial values byte size overflow".to_string()))?;
+        let partial_indices_bytes = partial_len
+            .checked_mul(mem::size_of::<u32>())
+            .ok_or_else(|| MetalError::OperationNotSupported("sampling kernel partial indices byte size overflow".to_string()))?;
+
+        let counts_bytes = threadgroup_count
+            .checked_mul(mem::size_of::<u32>())
+            .ok_or_else(|| MetalError::OperationNotSupported("sampling kernel counts byte size overflow".to_string()))?;
+
+        let fallback_bytes = threadgroup_count
+            .checked_mul(mem::size_of::<f32>())
+            .ok_or_else(|| MetalError::OperationNotSupported("sampling kernel fallback values byte size overflow".to_string()))?;
+
+        let fallback_index_bytes = threadgroup_count
+            .checked_mul(mem::size_of::<u32>())
+            .ok_or_else(|| MetalError::OperationNotSupported("sampling kernel fallback indices byte size overflow".to_string()))?;
+
+        let partial_vals = ctx
+            .device
+            .newBufferWithLength_options(partial_vals_bytes, MTLResourceOptions::StorageModePrivate)
+            .ok_or(MetalError::BufferCreationFailed(partial_vals_bytes))?;
+        let partial_indices = ctx
+            .device
+            .newBufferWithLength_options(partial_indices_bytes, MTLResourceOptions::StorageModePrivate)
+            .ok_or(MetalError::BufferCreationFailed(partial_indices_bytes))?;
+        let partial_counts = ctx
+            .device
+            .newBufferWithLength_options(counts_bytes, MTLResourceOptions::StorageModePrivate)
+            .ok_or(MetalError::BufferCreationFailed(counts_bytes))?;
+        let fallback_vals = ctx
+            .device
+            .newBufferWithLength_options(fallback_bytes, MTLResourceOptions::StorageModePrivate)
+            .ok_or(MetalError::BufferCreationFailed(fallback_bytes))?;
+        let fallback_indices = ctx
+            .device
+            .newBufferWithLength_options(fallback_index_bytes, MTLResourceOptions::StorageModePrivate)
+            .ok_or(MetalError::BufferCreationFailed(fallback_index_bytes))?;
+        let fallback_flags = ctx
+            .device
+            .newBufferWithLength_options(fallback_index_bytes, MTLResourceOptions::StorageModePrivate)
+            .ok_or(MetalError::BufferCreationFailed(fallback_index_bytes))?;
+
+        let completion_counter_bytes = mem::size_of::<u32>();
+        let completion_counter = ctx
+            .device
+            .newBufferWithLength_options(completion_counter_bytes, MTLResourceOptions::StorageModeShared)
+            .ok_or(MetalError::BufferCreationFailed(completion_counter_bytes))?;
+
+        unsafe {
+            let ptr = completion_counter.contents().as_ptr().cast::<u32>();
+            ptr.write_unaligned(0);
+        }
+
+        let params = SamplingParams {
+            vocab_size: raw_params.vocab_size,
+            top_k: effective_top_k as u32,
+            random_u32: raw_params.random_u32,
+            threadgroup_count: threadgroup_count as u32,
+            top_p: raw_params.top_p,
+            temperature: raw_params.temperature,
+            _padding0: 0,
+            _padding1: 0,
+        };
+
         let output = logits.clone();
         let op = SampleTopKTopP {
             logits,
             result,
+            partial_vals,
+            partial_indices,
+            partial_counts,
+            fallback_vals,
+            fallback_indices,
+            fallback_flags,
+            completion_counter,
             params,
             pipeline: pipeline.expect("Kernel Module should supply a pipeline"),
             dispatch_timing,
+            effective_top_k,
+            threadgroup_count,
         };
 
         Ok((Box::new(op), output))
@@ -88,6 +191,11 @@ impl<T: TensorElement> Operation for SampleTopKTopP<T> {
         let encoder = command_buffer
             .computeCommandEncoder()
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
+
+        unsafe {
+            let ptr = self.completion_counter.contents().as_ptr().cast::<u32>();
+            ptr.write_unaligned(0);
+        }
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), KernelDispatchKind::Compute)
@@ -106,20 +214,27 @@ impl<T: TensorElement> Operation for SampleTopKTopP<T> {
         set_compute_pipeline_state(&encoder, &self.pipeline);
         set_buffer(&encoder, 0, &self.logits.buf, self.logits.offset);
         set_buffer(&encoder, 1, &self.result, 0);
-        set_bytes(&encoder, 2, &self.params);
+        set_buffer(&encoder, 2, &self.partial_vals, 0);
+        set_buffer(&encoder, 3, &self.partial_indices, 0);
+        set_buffer(&encoder, 4, &self.partial_counts, 0);
+        set_buffer(&encoder, 5, &self.fallback_vals, 0);
+        set_buffer(&encoder, 6, &self.fallback_indices, 0);
+        set_buffer(&encoder, 7, &self.fallback_flags, 0);
+        set_buffer(&encoder, 8, &self.completion_counter, 0);
+        set_bytes(&encoder, 9, &self.params);
 
-        let grid_size = MTLSize {
-            width: THREADGROUP_SIZE as NSUInteger,
-            height: 1,
-            depth: 1,
-        };
         let threadgroup_size = MTLSize {
             width: THREADGROUP_SIZE as NSUInteger,
             height: 1,
             depth: 1,
         };
+        let threadgroups = MTLSize {
+            width: self.threadgroup_count as NSUInteger,
+            height: 1,
+            depth: 1,
+        };
 
-        dispatch_threads(&encoder, grid_size, threadgroup_size);
+        dispatch_threadgroups(&encoder, threadgroups, threadgroup_size);
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), KernelDispatchKind::Compute)

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -6,9 +6,8 @@ use crate::metallic::{TensorElement, tensor::RetainedBuffer};
 use objc2::msg_send;
 use objc2::runtime::{Bool, ProtocolObject};
 use objc2_foundation::NSUInteger;
-use objc2_metal::{MTLCounterSampleBuffer, MTLResourceOptions};
+use objc2_metal::{MTLBuffer, MTLCounterSampleBuffer, MTLResourceOptions};
 use std::mem;
-use std::ptr;
 
 /// Number of threads launched for the sampling reduction kernel. This must match
 /// `THREADGROUP_SIZE` in `kernel.metal`.

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -11,7 +11,7 @@ use std::mem;
 
 /// Number of threads launched for the sampling reduction kernel. This must match
 /// `THREADGROUP_SIZE` in `kernel.metal`.
-const THREADGROUP_SIZE: usize = 32;
+const THREADGROUP_SIZE: usize = 8;
 
 /// Maximum supported top-k for the GPU sampling kernel. Larger requests fall
 /// back to the CPU implementation to avoid excessive per-thread stack usage.

--- a/src/metallic/kernels/sampling/mod.rs
+++ b/src/metallic/kernels/sampling/mod.rs
@@ -1,6 +1,11 @@
 use super::*;
 
 use crate::metallic::{TensorElement, tensor::RetainedBuffer};
+use objc2_foundation::NSUInteger;
+
+/// Number of threads launched for the sampling reduction kernel. This must match
+/// `THREADGROUP_SIZE` in `kernel.metal`.
+const THREADGROUP_SIZE: usize = 8;
 
 /// Maximum supported top-k for the GPU sampling kernel. Larger requests fall
 /// back to the CPU implementation to avoid excessive per-thread stack usage.
@@ -76,12 +81,12 @@ impl<T: TensorElement> Operation for SampleTopKTopP<T> {
         set_bytes(&encoder, 2, &self.params);
 
         let grid_size = MTLSize {
-            width: 1,
+            width: THREADGROUP_SIZE as NSUInteger,
             height: 1,
             depth: 1,
         };
         let threadgroup_size = MTLSize {
-            width: 1,
+            width: THREADGROUP_SIZE as NSUInteger,
             height: 1,
             depth: 1,
         };

--- a/src/metallic/mod.rs
+++ b/src/metallic/mod.rs
@@ -1,5 +1,6 @@
-pub use context::{Context, KvCacheDispatchStats, SamplerBuffers};
+pub use context::{Context, KvCacheDispatchStats};
 pub use error::MetalError;
+pub use sampling::SamplerBuffers;
 pub use tensor::{Dtype, F16Element, F32Element, Tensor, TensorElement, TensorInit, TensorStorage};
 
 pub use tokenizer::{SpecialTokens, Tokenizer, TokenizerError};
@@ -16,6 +17,7 @@ pub mod metrics;
 pub mod operation;
 pub mod pool;
 pub mod resource_cache;
+pub mod sampling;
 pub mod tensor;
 pub mod tokenizer;
 pub use operation::{CommandBuffer, Operation};

--- a/src/metallic/sampling.rs
+++ b/src/metallic/sampling.rs
@@ -1,0 +1,167 @@
+use crate::metallic::TensorElement;
+use rand::RngCore;
+
+/// Workspace reused across sampling invocations to avoid per-token allocations.
+#[derive(Default)]
+pub struct SamplerBuffers {
+    pub scaled: Vec<f32>,
+    pub indices: Vec<usize>,
+}
+
+/// Compute the effective top-k value by clamping the requested `top_k` to the
+/// vocabulary size and enforcing a minimum of one candidate.
+#[inline]
+pub fn effective_top_k(top_k: usize, vocab_len: usize) -> usize {
+    top_k.max(1).min(vocab_len)
+}
+
+/// Sample from logits using top-k and top-p (nucleus) sampling with a fixed RNG draw.
+///
+/// This is the core implementation shared across CPU and GPU paths. The caller
+/// provides a deterministic `random_u32` to avoid consuming RNG state inside the
+/// routine, which allows the GPU kernel to share the same randomness and keeps
+/// unit tests deterministic.
+pub fn sample_top_k_top_p_with_random_value<T: TensorElement>(
+    logits: &[T::Scalar],
+    top_k: usize,
+    top_p: f32,
+    temperature: f32,
+    random_u32: u32,
+    buffers: &mut SamplerBuffers,
+) -> usize {
+    let mut fallback_idx = 0usize;
+    let mut fallback_found = false;
+    let mut fallback_val = f32::NEG_INFINITY;
+    for (i, &raw) in logits.iter().enumerate() {
+        let val = T::to_f32(raw);
+        if val.is_finite() && (!fallback_found || val > fallback_val || (val == fallback_val && i > fallback_idx)) {
+            fallback_idx = i;
+            fallback_val = val;
+            fallback_found = true;
+        }
+    }
+
+    if temperature <= 0.0 || !temperature.is_finite() {
+        return if fallback_found { fallback_idx } else { 0 };
+    }
+
+    if logits.is_empty() {
+        return 0;
+    }
+
+    if top_k == 0 {
+        return if fallback_found { fallback_idx } else { 0 };
+    }
+
+    let effective_top_k = effective_top_k(top_k, logits.len());
+
+    let scaled = &mut buffers.scaled;
+    scaled.clear();
+    if scaled.capacity() < effective_top_k {
+        scaled.reserve(effective_top_k);
+    }
+
+    let indices = &mut buffers.indices;
+    indices.clear();
+    if indices.capacity() < effective_top_k {
+        indices.reserve(effective_top_k);
+    }
+
+    for (i, &raw) in logits.iter().enumerate() {
+        let val = T::to_f32(raw);
+        let scaled_val = val / temperature;
+        if !scaled_val.is_finite() {
+            continue;
+        }
+
+        let insert_pos = scaled.partition_point(|&existing| existing > scaled_val);
+        if indices.len() < effective_top_k {
+            scaled.insert(insert_pos, scaled_val);
+            indices.insert(insert_pos, i);
+        } else if insert_pos < effective_top_k {
+            scaled.insert(insert_pos, scaled_val);
+            indices.insert(insert_pos, i);
+            scaled.pop();
+            indices.pop();
+        }
+    }
+
+    if indices.is_empty() {
+        return if fallback_found { fallback_idx } else { 0 };
+    }
+
+    let mut has_positive = false;
+    let max_val = scaled[0];
+    let mut total = 0.0f32;
+    for val in scaled.iter_mut() {
+        if val.is_finite() {
+            let mut exp_val = (*val - max_val).exp();
+            if exp_val > 1e10 {
+                exp_val = 1e10;
+            } else if exp_val < 1e-10 {
+                exp_val = 0.0;
+            }
+            *val = exp_val;
+        } else {
+            *val = 0.0;
+        }
+        total += *val;
+        has_positive |= *val > 0.0;
+    }
+
+    if !has_positive || total <= 0.0 || total.is_infinite() || total.is_nan() {
+        return if fallback_found { fallback_idx } else { 0 };
+    }
+
+    let normalized_top_p = if top_p.is_finite() { top_p.clamp(0.0, 1.0) } else { 1.0 };
+    let mut cutoff = indices.len() - 1;
+    if normalized_top_p <= 0.0 {
+        cutoff = 0;
+    } else if normalized_top_p < 1.0 {
+        let mut cum = 0.0f32;
+        let threshold = normalized_top_p * total;
+        for (i, &weight) in scaled.iter().enumerate() {
+            cum += weight;
+            cutoff = i;
+            if cum >= threshold || cum.is_infinite() || cum.is_nan() {
+                break;
+            }
+        }
+    }
+
+    scaled.truncate(cutoff + 1);
+    indices.truncate(cutoff + 1);
+
+    let shortlist_total: f32 = scaled.iter().sum();
+    if shortlist_total <= 0.0 || shortlist_total.is_infinite() || shortlist_total.is_nan() {
+        return indices.first().copied().unwrap_or(if fallback_found { fallback_idx } else { 0 });
+    }
+
+    for weight in scaled.iter_mut() {
+        *weight /= shortlist_total;
+    }
+
+    let r = (random_u32 as f32) / (u32::MAX as f32);
+    let mut acc = 0.0f32;
+    for (&idx, &prob) in indices.iter().zip(scaled.iter()) {
+        acc += prob;
+        if r <= acc || acc.is_infinite() || acc.is_nan() {
+            return idx;
+        }
+    }
+
+    indices.last().copied().unwrap_or(if fallback_found { fallback_idx } else { 0 })
+}
+
+/// Convenience wrapper that sources randomness from the thread-local RNG.
+pub fn sample_top_k_top_p<T: TensorElement>(
+    logits: &[T::Scalar],
+    top_k: usize,
+    top_p: f32,
+    temperature: f32,
+    buffers: &mut SamplerBuffers,
+) -> usize {
+    let mut rng = rand::rng();
+    let random_u32 = rng.next_u32();
+    sample_top_k_top_p_with_random_value::<T>(logits, top_k, top_p, temperature, random_u32, buffers)
+}

--- a/src/metallic/tests/clamping_extreme_test.rs
+++ b/src/metallic/tests/clamping_extreme_test.rs
@@ -1,4 +1,5 @@
-use crate::metallic::{F32Element, SamplerBuffers, generation::sample_top_k_top_p};
+use crate::metallic::sampling::sample_top_k_top_p;
+use crate::metallic::{F32Element, SamplerBuffers};
 
 #[test]
 fn test_sample_top_k_top_p_extreme_logits() {


### PR DESCRIPTION
## Summary
- add a Metal compute kernel and context helper to perform top-k/top-p sampling on device while reusing a shared RNG
- move the CPU sampling implementation into a shared module and update generation to use the GPU path when supported without materializing logits on the host
- extend sampling tests to cover GPU/CPU parity and add a Criterion benchmark comparing the legacy host path with the new kernel

## Testing
- not run (Metal runtime unavailable in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1a306cfd48326ace3fe979710fc0a