### PR TITLE
Refactor KV cache layout for grouped attention

### DIFF
--- a/src/metallic/instrumentation.rs
+++ b/src/metallic/instrumentation.rs
@@ -200,16 +200,17 @@ impl MatMulInstrumentation {
             } = dispatch;
 
             if let Some(timing) = timing.as_ref()
-                && let Some(duration) = self.inner.resolve_duration(timing) {
-                    recorder.record(MatMulSample {
-                        backend,
-                        duration,
-                        dims,
-                        handle: Some(handle),
-                    });
-                    resolved_total += duration;
-                    continue;
-                }
+                && let Some(duration) = self.inner.resolve_duration(timing)
+            {
+                recorder.record(MatMulSample {
+                    backend,
+                    duration,
+                    dims,
+                    handle: Some(handle),
+                });
+                resolved_total += duration;
+                continue;
+            }
 
             fallback.push(PendingDispatch {
                 handle,
@@ -715,13 +716,11 @@ impl BlockLatencySnapshot {
     }
 }
 
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BlockPhaseSnapshot {
     pub label: String,
     pub duration: Duration,
 }
-
 
 /// Helper to create a new collector handle for the desired number of transformer blocks.
 pub fn new_latency_collector(block_count: usize) -> LatencyCollectorHandle {
@@ -1086,8 +1085,7 @@ impl BlockMemorySnapshot {
     }
 }
 
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MemoryPhaseSnapshot {
     pub label: String,
     pub current_pool_delta: usize,
@@ -1097,7 +1095,6 @@ pub struct MemoryPhaseSnapshot {
     pub peak_kv_delta: usize,
     pub peak_kv_cache_delta: usize,
 }
-
 
 #[derive(Clone, Debug, Default)]
 pub struct StepMemorySnapshot {

--- a/src/metallic/kernels/gemv/mod.rs
+++ b/src/metallic/kernels/gemv/mod.rs
@@ -43,17 +43,18 @@ impl<T: TensorElement> Operation for Gemv<T> {
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.start_index(),
-                        withBarrier: Bool::YES
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
             }
+        }
 
         set_compute_pipeline_state(&encoder, &self.pipeline);
         set_buffer(&encoder, 0, &self.a.buf, self.a.offset);
@@ -64,17 +65,18 @@ impl<T: TensorElement> Operation for Gemv<T> {
         dispatch_threadgroups(&encoder, self.grid_size, self.threadgroup_size);
 
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.end_index(),
-                        withBarrier: Bool::NO
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
             }
+        }
 
         encoder.endEncoding();
         Ok(())

--- a/src/metallic/kernels/kv_cache_write/kernel.metal
+++ b/src/metallic/kernels/kv_cache_write/kernel.metal
@@ -11,27 +11,26 @@ kernel void kv_cache_write_kernel_##SUFFIX( \
     device const SCALAR* v_src [[buffer(1)]], \
     device SCALAR* k_dst [[buffer(2)]], \
     device SCALAR* v_dst [[buffer(3)]], \
-    device SCALAR* repeated_k_dst [[buffer(4)]], \
-    device SCALAR* repeated_v_dst [[buffer(5)]], \
-    constant uint& canonical_heads [[buffer(6)]], \
-    constant uint& head_dim [[buffer(7)]], \
-    constant uint& seq_len [[buffer(8)]], \
-    constant uint& step [[buffer(9)]], \
-    constant uint& group_size [[buffer(10)]], \
-    constant uint& src_head_stride [[buffer(11)]], \
-    constant uint& src_seq_stride [[buffer(12)]], \
-    constant uint& dst_head_stride [[buffer(13)]], \
-    constant uint& dst_seq_stride [[buffer(14)]], \
-    constant uint& repeated_head_stride [[buffer(15)]], \
-    constant uint& repeated_seq_stride [[buffer(16)]], \
-    constant uint& has_repeated [[buffer(17)]], \
-    constant uint& total_threads [[buffer(18)]], \
+    constant uint& canonical_heads [[buffer(4)]], \
+    constant uint& head_dim [[buffer(5)]], \
+    constant uint& seq_len [[buffer(6)]], \
+    constant uint& step [[buffer(7)]], \
+    constant uint& group_size [[buffer(8)]], \
+    constant uint& src_head_stride [[buffer(9)]], \
+    constant uint& src_seq_stride [[buffer(10)]], \
+    constant uint& dst_head_stride [[buffer(11)]], \
+    constant uint& dst_seq_stride [[buffer(12)]], \
+    constant uint& total_threads [[buffer(13)]], \
+    constant uint& repeated_heads [[buffer(14)]], \
     uint gid [[thread_position_in_grid]]) { \
     if (gid >= total_threads) { \
         return; \
     } \
     uint head_idx = gid / head_dim; \
     if (head_idx >= canonical_heads) { \
+        return; \
+    } \
+    if (repeated_heads < canonical_heads * group_size) { \
         return; \
     } \
     uint dim_idx = gid % head_dim; \
@@ -41,18 +40,12 @@ kernel void kv_cache_write_kernel_##SUFFIX( \
         SCALAR k_value = k_src[k_src_index]; \
         SCALAR v_value = v_src[v_src_index]; \
         uint cache_step = step + seq_idx; \
-        uint k_dst_index = head_idx * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
-        uint v_dst_index = head_idx * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
-        k_dst[k_dst_index] = k_value; \
-        v_dst[v_dst_index] = v_value; \
-        if (has_repeated != 0) { \
-            for (uint group = 0; group < group_size; ++group) { \
-                uint dst_head = head_idx * group_size + group; \
-                uint repeated_k_index = dst_head * repeated_head_stride + cache_step * repeated_seq_stride + dim_idx; \
-                uint repeated_v_index = dst_head * repeated_head_stride + cache_step * repeated_seq_stride + dim_idx; \
-                repeated_k_dst[repeated_k_index] = k_value; \
-                repeated_v_dst[repeated_v_index] = v_value; \
-            } \
+        for (uint group = 0; group < group_size; ++group) { \
+            uint dst_head = head_idx * group_size + group; \
+            uint dst_k_index = dst_head * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
+            uint dst_v_index = dst_head * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
+            k_dst[dst_k_index] = k_value; \
+            v_dst[dst_v_index] = v_value; \
         } \
     } \
 }

--- a/src/metallic/kernels/kv_cache_write/mod.rs
+++ b/src/metallic/kernels/kv_cache_write/mod.rs
@@ -15,9 +15,7 @@ pub struct KvCacheWriteConfig {
     pub dst_head_stride: u32,
     pub dst_seq_stride: u32,
     pub total_threads: u32,
-    pub repeated_head_stride: u32,
-    pub repeated_seq_stride: u32,
-    pub has_repeated: u32,
+    pub repeated_heads: u32,
 }
 
 struct KvCacheWrite<T: TensorElement> {
@@ -25,21 +23,12 @@ struct KvCacheWrite<T: TensorElement> {
     v_src: Tensor<T>,
     k_dst: Tensor<T>,
     v_dst: Tensor<T>,
-    repeated_k_dst: Option<Tensor<T>>,
-    repeated_v_dst: Option<Tensor<T>>,
     params: KvCacheWriteConfig,
     pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
 }
 
 impl KernelInvocable for KvCacheWriteOp {
-    type Args<'a, T: TensorElement> = (
-        Tensor<T>,
-        Tensor<T>,
-        Tensor<T>,
-        Tensor<T>,
-        Option<(Tensor<T>, Tensor<T>)>,
-        KvCacheWriteConfig,
-    );
+    type Args<'a, T: TensorElement> = (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>, KvCacheWriteConfig);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::KvCacheWrite)
@@ -51,7 +40,7 @@ impl KernelInvocable for KvCacheWriteOp {
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor<T>), MetalError> {
-        let (k_src, v_src, k_dst, v_dst, repeated, params) = args;
+        let (k_src, v_src, k_dst, v_dst, params) = args;
 
         if params.canonical_heads == 0 {
             return Err(MetalError::InvalidShape(
@@ -74,17 +63,7 @@ impl KernelInvocable for KvCacheWriteOp {
             ));
         }
 
-        if params.has_repeated > 1 {
-            return Err(MetalError::InvalidShape(
-                "kv_cache_write expects has_repeated flag to be 0 or 1".to_string(),
-            ));
-        }
-
-        let mut tensors: Vec<&Tensor<T>> = vec![&k_src, &v_src, &k_dst, &v_dst];
-        if let Some((ref repeated_k, ref repeated_v)) = repeated {
-            tensors.push(repeated_k);
-            tensors.push(repeated_v);
-        }
+        let tensors: Vec<&Tensor<T>> = vec![&k_src, &v_src, &k_dst, &v_dst];
 
         ctx.prepare_tensors_for_active_cmd(&tensors)?;
 
@@ -94,8 +73,6 @@ impl KernelInvocable for KvCacheWriteOp {
             v_src,
             k_dst: k_dst.clone(),
             v_dst,
-            repeated_k_dst: repeated.as_ref().map(|(k, _)| k.clone()),
-            repeated_v_dst: repeated.map(|(_, v)| v),
             params,
             pipeline,
         };
@@ -130,23 +107,17 @@ impl<T: TensorElement> Operation for KvCacheWrite<T> {
         set_buffer(&encoder, 1, &self.v_src.buf, self.v_src.offset);
         set_buffer(&encoder, 2, &self.k_dst.buf, self.k_dst.offset);
         set_buffer(&encoder, 3, &self.v_dst.buf, self.v_dst.offset);
-        let repeated_k = self.repeated_k_dst.as_ref().unwrap_or(&self.k_dst);
-        let repeated_v = self.repeated_v_dst.as_ref().unwrap_or(&self.v_dst);
-        set_buffer(&encoder, 4, &repeated_k.buf, repeated_k.offset);
-        set_buffer(&encoder, 5, &repeated_v.buf, repeated_v.offset);
-        set_bytes(&encoder, 6, &self.params.canonical_heads);
-        set_bytes(&encoder, 7, &self.params.head_dim);
-        set_bytes(&encoder, 8, &self.params.seq_len);
-        set_bytes(&encoder, 9, &self.params.step);
-        set_bytes(&encoder, 10, &self.params.group_size);
-        set_bytes(&encoder, 11, &self.params.src_head_stride);
-        set_bytes(&encoder, 12, &self.params.src_seq_stride);
-        set_bytes(&encoder, 13, &self.params.dst_head_stride);
-        set_bytes(&encoder, 14, &self.params.dst_seq_stride);
-        set_bytes(&encoder, 15, &self.params.repeated_head_stride);
-        set_bytes(&encoder, 16, &self.params.repeated_seq_stride);
-        set_bytes(&encoder, 17, &self.params.has_repeated);
-        set_bytes(&encoder, 18, &self.params.total_threads);
+        set_bytes(&encoder, 4, &self.params.canonical_heads);
+        set_bytes(&encoder, 5, &self.params.head_dim);
+        set_bytes(&encoder, 6, &self.params.seq_len);
+        set_bytes(&encoder, 7, &self.params.step);
+        set_bytes(&encoder, 8, &self.params.group_size);
+        set_bytes(&encoder, 9, &self.params.src_head_stride);
+        set_bytes(&encoder, 10, &self.params.src_seq_stride);
+        set_bytes(&encoder, 11, &self.params.dst_head_stride);
+        set_bytes(&encoder, 12, &self.params.dst_seq_stride);
+        set_bytes(&encoder, 13, &self.params.total_threads);
+        set_bytes(&encoder, 14, &self.params.repeated_heads);
 
         dispatch_threadgroups(&encoder, groups, threads_per_tg);
         encoder.endEncoding();

--- a/src/metallic/kernels/matmul/matmul_alpha_beta.rs
+++ b/src/metallic/kernels/matmul/matmul_alpha_beta.rs
@@ -211,18 +211,19 @@ impl Operation for MatMulAlphaBeta {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.start_index(),
-                            withBarrier: Bool::YES
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         // Encode the MPS matrix multiplication
         unsafe {
@@ -233,18 +234,19 @@ impl Operation for MatMulAlphaBeta {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.end_index(),
-                            withBarrier: Bool::NO
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         Ok(())
     }

--- a/src/metallic/kernels/matmul/mod.rs
+++ b/src/metallic/kernels/matmul/mod.rs
@@ -240,18 +240,19 @@ impl Operation for MatMul {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.start_index(),
-                            withBarrier: Bool::YES
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         // Encode the MPS matrix multiplication
         unsafe {
@@ -262,18 +263,19 @@ impl Operation for MatMul {
 
         if let Some(timing) = &self.dispatch_timing
             && matches!(timing.kind(), MatMulDispatchKind::Blit)
-                && let Some(encoder) = command_buffer.blitCommandEncoder() {
-                    let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                    unsafe {
-                        let _: () = msg_send![
-                            &*encoder,
-                            sampleCountersInBuffer: sample_buffer,
-                            atSampleIndex: timing.end_index(),
-                            withBarrier: Bool::NO
-                        ];
-                    }
-                    encoder.endEncoding();
-                }
+            && let Some(encoder) = command_buffer.blitCommandEncoder()
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
+            }
+            encoder.endEncoding();
+        }
 
         Ok(())
     }

--- a/src/metallic/kernels/mlxmatmul/mlx.rs
+++ b/src/metallic/kernels/mlxmatmul/mlx.rs
@@ -435,17 +435,18 @@ impl<T: TensorElement> Operation for MatMulMlx<T> {
             .ok_or(MetalError::ComputeEncoderCreationFailed)?;
 
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.start_index(),
-                        withBarrier: Bool::YES
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.start_index(),
+                    withBarrier: Bool::YES
+                ];
             }
+        }
 
         set_compute_pipeline_state(&encoder, &self.pipeline);
         set_buffer(&encoder, 0, &self.left.buf, self.left.offset);
@@ -482,17 +483,18 @@ impl<T: TensorElement> Operation for MatMulMlx<T> {
 
         dispatch_threadgroups(&encoder, self.threadgroups, self.threads_per_tg);
         if let Some(timing) = &self.dispatch_timing
-            && matches!(timing.kind(), MatMulDispatchKind::Compute) {
-                let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
-                unsafe {
-                    let _: () = msg_send![
-                        &*encoder,
-                        sampleCountersInBuffer: sample_buffer,
-                        atSampleIndex: timing.end_index(),
-                        withBarrier: Bool::NO
-                    ];
-                }
+            && matches!(timing.kind(), MatMulDispatchKind::Compute)
+        {
+            let sample_buffer: &ProtocolObject<dyn MTLCounterSampleBuffer> = timing.sample_buffer();
+            unsafe {
+                let _: () = msg_send![
+                    &*encoder,
+                    sampleCountersInBuffer: sample_buffer,
+                    atSampleIndex: timing.end_index(),
+                    withBarrier: Bool::NO
+                ];
             }
+        }
         encoder.endEncoding();
         Ok(())
     }


### PR DESCRIPTION
## Summary
- replace the dual canonical/repeated KV cache with a single attention-ready allocation and write path
- update the grouped KV cache write kernel to emit repeated heads directly from canonical inputs
- adjust Qwen forward pass, documentation, and regression tests to consume the unified cache layout

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e1e40fa8988326a2d6b0bbf58d57ac