### PR TITLE
Store canonical KV caches and expand query heads on demand

### DIFF
--- a/src/metallic/kernels/kv_cache_write/kernel.metal
+++ b/src/metallic/kernels/kv_cache_write/kernel.metal
@@ -15,22 +15,17 @@ kernel void kv_cache_write_kernel_##SUFFIX( \
     constant uint& head_dim [[buffer(5)]], \
     constant uint& seq_len [[buffer(6)]], \
     constant uint& step [[buffer(7)]], \
-    constant uint& group_size [[buffer(8)]], \
-    constant uint& src_head_stride [[buffer(9)]], \
-    constant uint& src_seq_stride [[buffer(10)]], \
-    constant uint& dst_head_stride [[buffer(11)]], \
-    constant uint& dst_seq_stride [[buffer(12)]], \
-    constant uint& total_threads [[buffer(13)]], \
-    constant uint& repeated_heads [[buffer(14)]], \
+    constant uint& src_head_stride [[buffer(8)]], \
+    constant uint& src_seq_stride [[buffer(9)]], \
+    constant uint& dst_head_stride [[buffer(10)]], \
+    constant uint& dst_seq_stride [[buffer(11)]], \
+    constant uint& total_threads [[buffer(12)]], \
     uint gid [[thread_position_in_grid]]) { \
     if (gid >= total_threads) { \
         return; \
     } \
     uint head_idx = gid / head_dim; \
     if (head_idx >= canonical_heads) { \
-        return; \
-    } \
-    if (repeated_heads < canonical_heads * group_size) { \
         return; \
     } \
     uint dim_idx = gid % head_dim; \
@@ -40,13 +35,10 @@ kernel void kv_cache_write_kernel_##SUFFIX( \
         SCALAR k_value = k_src[k_src_index]; \
         SCALAR v_value = v_src[v_src_index]; \
         uint cache_step = step + seq_idx; \
-        for (uint group = 0; group < group_size; ++group) { \
-            uint dst_head = head_idx * group_size + group; \
-            uint dst_k_index = dst_head * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
-            uint dst_v_index = dst_head * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
-            k_dst[dst_k_index] = k_value; \
-            v_dst[dst_v_index] = v_value; \
-        } \
+        uint dst_k_index = head_idx * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
+        uint dst_v_index = head_idx * dst_head_stride + cache_step * dst_seq_stride + dim_idx; \
+        k_dst[dst_k_index] = k_value; \
+        v_dst[dst_v_index] = v_value; \
     } \
 }
 

--- a/src/metallic/kernels/kv_cache_write/mod.rs
+++ b/src/metallic/kernels/kv_cache_write/mod.rs
@@ -9,13 +9,11 @@ pub struct KvCacheWriteConfig {
     pub head_dim: u32,
     pub seq_len: u32,
     pub step: u32,
-    pub group_size: u32,
     pub src_head_stride: u32,
     pub src_seq_stride: u32,
     pub dst_head_stride: u32,
     pub dst_seq_stride: u32,
     pub total_threads: u32,
-    pub repeated_heads: u32,
 }
 
 struct KvCacheWrite<T: TensorElement> {
@@ -57,12 +55,6 @@ impl KernelInvocable for KvCacheWriteOp {
                 "kv_cache_write expects at least one active sequence element".to_string(),
             ));
         }
-        if params.group_size == 0 {
-            return Err(MetalError::InvalidShape(
-                "kv_cache_write requires a non-zero group size".to_string(),
-            ));
-        }
-
         let tensors: Vec<&Tensor<T>> = vec![&k_src, &v_src, &k_dst, &v_dst];
 
         ctx.prepare_tensors_for_active_cmd(&tensors)?;
@@ -111,13 +103,11 @@ impl<T: TensorElement> Operation for KvCacheWrite<T> {
         set_bytes(&encoder, 5, &self.params.head_dim);
         set_bytes(&encoder, 6, &self.params.seq_len);
         set_bytes(&encoder, 7, &self.params.step);
-        set_bytes(&encoder, 8, &self.params.group_size);
-        set_bytes(&encoder, 9, &self.params.src_head_stride);
-        set_bytes(&encoder, 10, &self.params.src_seq_stride);
-        set_bytes(&encoder, 11, &self.params.dst_head_stride);
-        set_bytes(&encoder, 12, &self.params.dst_seq_stride);
-        set_bytes(&encoder, 13, &self.params.total_threads);
-        set_bytes(&encoder, 14, &self.params.repeated_heads);
+        set_bytes(&encoder, 8, &self.params.src_head_stride);
+        set_bytes(&encoder, 9, &self.params.src_seq_stride);
+        set_bytes(&encoder, 10, &self.params.dst_head_stride);
+        set_bytes(&encoder, 11, &self.params.dst_seq_stride);
+        set_bytes(&encoder, 12, &self.params.total_threads);
 
         dispatch_threadgroups(&encoder, groups, threads_per_tg);
         encoder.endEncoding();

--- a/src/metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
+++ b/src/metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
@@ -86,7 +86,7 @@ fn test_incremental_repeated_cache_matches_kernel() -> Result<(), MetalError> {
     let head_dim = 5usize;
 
     let layer_idx = 0usize;
-    ctx.alloc_kv_cache(layer_idx, cache_capacity, batch * n_heads, head_dim)?;
+    ctx.alloc_kv_cache(layer_idx, cache_capacity, batch * n_kv_heads, head_dim, group_size)?;
 
     let mut canonical_k = vec![0f32; batch * n_kv_heads * seq * head_dim];
     let mut canonical_v = vec![0f32; batch * n_kv_heads * seq * head_dim];


### PR DESCRIPTION
## Summary
- allocate KV caches in canonical [batch * n_kv_heads, seq, head] layout and track per-layer group size metadata
- simplify the Metal KV cache write path to avoid group duplication and update SDPA to repeat heads on demand
- refresh Qwen and cache tests to cover the canonical layout and the runtime expansion helpers

## Testing
- `cargo fmt`
- Tests not run (Metal backend unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e29c2dd188832680cd7a80e69bb0a4