### PR TITLE
Fix SDPA query slicing and add incremental tests

### DIFF
--- a/src/metallic/context.rs
+++ b/src/metallic/context.rs
@@ -1686,6 +1686,10 @@ impl<T: TensorElement> Context<T> {
         SdpaWorkspaceKey::from_tensor(tensor)
     }
 
+    pub(crate) fn has_sdpa_workspace(&self, key: SdpaWorkspaceKey) -> bool {
+        self.sdpa_workspaces.contains_key(&key)
+    }
+
     pub(crate) fn reset_sdpa_workspace(&mut self, key: SdpaWorkspaceKey) {
         self.sdpa_workspaces.remove(&key);
     }

--- a/src/metallic/kernels/scaled_dot_product_attention/mod.rs
+++ b/src/metallic/kernels/scaled_dot_product_attention/mod.rs
@@ -155,8 +155,13 @@ fn create_sdpa_operation<T: TensorElement>(
         s_q
     } else {
         let remaining = s_q.saturating_sub(offset_usize);
-        let capped = seq_len_delta.min(remaining);
-        if capped == 0 { remaining } else { capped }
+        let growth = seq_len_delta.min(s_q);
+
+        if remaining > 0 {
+            if growth == 0 { remaining } else { remaining.min(growth) }
+        } else {
+            growth
+        }
     };
 
     if rows_to_process == 0 {


### PR DESCRIPTION
## Summary
- ensure optimized SDPA processes the full query length when no cache offset is provided
- replace the unsupported multi-axis tensor slice with a manual strided view for batched query windows
- add regression tests that cover short key sequences and incremental decoding query offsets

## Testing
- not run (Metal-dependent environment unavailable in the sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e2ca85d0b48326a1aa60c37bc10bc6