### PR TITLE
Optimize KV head repetition with reusable workspace

### DIFF
--- a/src/metallic/kernels/repeat_kv_heads/kernel.metal
+++ b/src/metallic/kernels/repeat_kv_heads/kernel.metal
@@ -31,7 +31,7 @@ kernel void repeat_kv_heads_kernel_##SUFFIX( \
     uint h = batch_head_idx % n_heads; \
     uint kv_head = h / group_size; \
     uint input_batch_head = b * n_kv_heads + kv_head; \
-    uint input_index = ((input_batch_head * cache_stride) + dest_offset + seq_idx) * head_dim + dim_idx; \
+    uint input_index = ((input_batch_head * cache_stride) + seq_idx) * head_dim + dim_idx; \
     uint output_index = ((batch_head_idx * output_stride) + dest_offset + seq_idx) * head_dim + dim_idx; \
     output[output_index] = input[input_index]; \
 }

--- a/src/metallic/kernels/repeat_kv_heads/kernel.metal
+++ b/src/metallic/kernels/repeat_kv_heads/kernel.metal
@@ -16,7 +16,9 @@ kernel void repeat_kv_heads_kernel_##SUFFIX( \
     constant uint& seq [[buffer(6)]], \
     constant uint& head_dim [[buffer(7)]], \
     constant uint& cache_stride [[buffer(8)]], \
-    constant uint& total_elements [[buffer(9)]], \
+    constant uint& dest_offset [[buffer(9)]], \
+    constant uint& output_stride [[buffer(10)]], \
+    constant uint& total_elements [[buffer(11)]], \
     uint gid [[thread_position_in_grid]]) { \
     if (gid >= total_elements) { \
         return; \
@@ -29,8 +31,9 @@ kernel void repeat_kv_heads_kernel_##SUFFIX( \
     uint h = batch_head_idx % n_heads; \
     uint kv_head = h / group_size; \
     uint input_batch_head = b * n_kv_heads + kv_head; \
-    uint input_index = ((input_batch_head * cache_stride) + seq_idx) * head_dim + dim_idx; \
-    output[gid] = input[input_index]; \
+    uint input_index = ((input_batch_head * cache_stride) + dest_offset + seq_idx) * head_dim + dim_idx; \
+    uint output_index = ((batch_head_idx * output_stride) + dest_offset + seq_idx) * head_dim + dim_idx; \
+    output[output_index] = input[input_index]; \
 }
 
 FOR_EACH_FLOAT_TYPE(DEFINE_REPEAT_KV_KERNEL)

--- a/src/metallic/kernels/repeat_kv_heads/mod.rs
+++ b/src/metallic/kernels/repeat_kv_heads/mod.rs
@@ -13,12 +13,15 @@ struct RepeatKvHeads<T: TensorElement> {
     seq: u32,
     head_dim: u32,
     cache_stride: u32,
+    dest_offset: u32,
+    output_stride: u32,
     total_elements: u32,
     pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
 }
 
 impl KernelInvocable for RepeatKvHeadsOp {
-    type Args<'a, T: TensorElement> = (Tensor<T>, u32, u32, u32, u32, u32, u32, u32);
+    #[allow(clippy::type_complexity)]
+    type Args<'a, T: TensorElement> = (Tensor<T>, Option<Tensor<T>>, u32, u32, u32, u32, u32, u32, u32, u32);
 
     fn function_id() -> Option<KernelFunction> {
         Some(KernelFunction::RepeatKvHeads)
@@ -30,7 +33,7 @@ impl KernelInvocable for RepeatKvHeadsOp {
         pipeline: Option<Retained<ProtocolObject<dyn MTLComputePipelineState>>>,
         _cache: Option<&mut ResourceCache>,
     ) -> Result<(Box<dyn Operation>, Tensor<T>), MetalError> {
-        let (input, group_size, batch, n_kv_heads, n_heads, seq, head_dim, cache_stride) = args;
+        let (input, output_override, dest_offset, group_size, batch, n_kv_heads, n_heads, seq, head_dim, cache_stride) = args;
 
         if group_size == 0 {
             return Err(MetalError::InvalidShape(
@@ -60,12 +63,6 @@ impl KernelInvocable for RepeatKvHeadsOp {
                 "Active sequence length for repeat_kv_heads must be greater than zero".to_string(),
             ));
         }
-        if seq > cache_stride {
-            return Err(MetalError::InvalidShape(format!(
-                "Active sequence length ({}) exceeds cache stride ({})",
-                seq, cache_stride
-            )));
-        }
 
         let input_dims = input.dims();
         if input_dims.len() != 3 || input_dims[0] != (batch * n_kv_heads) as usize || input_dims[2] != head_dim as usize {
@@ -74,10 +71,11 @@ impl KernelInvocable for RepeatKvHeadsOp {
                 input_dims
             )));
         }
-        if input_dims[1] != seq as usize {
+        let required_input = dest_offset as usize + seq as usize;
+        if input_dims[1] < required_input {
             return Err(MetalError::InvalidShape(format!(
-                "Input sequence ({}) must match active sequence ({})",
-                input_dims[1], seq
+                "Input sequence (len={}) is smaller than requested range dest_offset ({}) + seq ({})",
+                input_dims[1], dest_offset, seq
             )));
         }
 
@@ -95,15 +93,69 @@ impl KernelInvocable for RepeatKvHeadsOp {
             )));
         }
 
-        ctx.prepare_tensors_for_active_cmd(&[&input])?;
+        let mut output = if let Some(tensor) = output_override {
+            tensor
+        } else {
+            let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];
+            Tensor::new(output_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?
+        };
 
-        let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];
-        let output = Tensor::new(output_dims, TensorStorage::Pooled(ctx), TensorInit::Uninitialized)?;
-        let total_elements = output.len() as u32;
+        let output_dims = output.dims().to_vec();
+        if output_dims.len() != 3 || output_dims[0] != (batch * n_heads) as usize || output_dims[2] != head_dim as usize {
+            return Err(MetalError::InvalidShape(format!(
+                "Output dims {:?} must be [batch*n_heads, cache_capacity, head_dim]",
+                output_dims
+            )));
+        }
+
+        let output_strides = output.strides.clone();
+        if output_strides.len() < 2 {
+            return Err(MetalError::InvalidShape(
+                "Output tensor for repeat_kv_heads must expose at least two strides".to_string(),
+            ));
+        }
+
+        if output_strides[2] != 1 {
+            return Err(MetalError::InvalidShape(
+                "Output tensor for repeat_kv_heads must have contiguous head_dim stride".to_string(),
+            ));
+        }
+
+        let output_stride = output_strides[0]
+            .checked_div(head_dim as usize)
+            .ok_or_else(|| MetalError::InvalidShape("Output tensor batch stride must be divisible by head_dim".to_string()))?;
+
+        let required_output = dest_offset as usize + seq as usize;
+        if required_output > output_stride {
+            return Err(MetalError::InvalidShape(format!(
+                "Requested output range dest_offset ({}) + seq ({}) exceeds output capacity ({})",
+                dest_offset, seq, output_stride
+            )));
+        }
+
+        ctx.prepare_tensors_for_active_cmd(&[&input, &output])?;
+
+        let total_elements_u64 = (batch as u64)
+            .checked_mul(n_heads as u64)
+            .and_then(|v| v.checked_mul(seq as u64))
+            .and_then(|v| v.checked_mul(head_dim as u64))
+            .ok_or_else(|| MetalError::InvalidShape("repeat_kv_heads element count overflowed u32".to_string()))?;
+
+        if total_elements_u64 == 0 {
+            return Err(MetalError::InvalidShape(
+                "repeat_kv_heads requires a non-zero element count".to_string(),
+            ));
+        }
+
+        let total_elements = total_elements_u64 as u32;
+
+        let mut output_view = output.clone();
+        output_view.dims = vec![(batch * n_heads) as usize, (dest_offset + seq) as usize, head_dim as usize];
+        output_view.strides = output.strides.clone();
 
         let op = RepeatKvHeads {
             input,
-            output: output.clone(),
+            output: output_view.clone(),
             group_size,
             batch,
             n_kv_heads,
@@ -111,11 +163,13 @@ impl KernelInvocable for RepeatKvHeadsOp {
             seq,
             head_dim,
             cache_stride,
+            dest_offset,
+            output_stride: output_stride as u32,
             total_elements,
             pipeline: pipeline.expect("Kernel Library supplied for MetalKernels"),
         };
 
-        Ok((Box::new(op), output))
+        Ok((Box::new(op), output_view))
     }
 }
 
@@ -150,7 +204,9 @@ impl<T: TensorElement> Operation for RepeatKvHeads<T> {
         set_bytes(&encoder, 6, &self.seq);
         set_bytes(&encoder, 7, &self.head_dim);
         set_bytes(&encoder, 8, &self.cache_stride);
-        set_bytes(&encoder, 9, &self.total_elements);
+        set_bytes(&encoder, 9, &self.dest_offset);
+        set_bytes(&encoder, 10, &self.output_stride);
+        set_bytes(&encoder, 11, &self.total_elements);
 
         dispatch_threadgroups(&encoder, groups, threads_per_tg);
         encoder.endEncoding();

--- a/src/metallic/kernels/repeat_kv_heads/mod.rs
+++ b/src/metallic/kernels/repeat_kv_heads/mod.rs
@@ -93,7 +93,7 @@ impl KernelInvocable for RepeatKvHeadsOp {
             )));
         }
 
-        let mut output = if let Some(tensor) = output_override {
+        let output = if let Some(tensor) = output_override {
             tensor
         } else {
             let output_dims = vec![(batch * n_heads) as usize, seq as usize, head_dim as usize];

--- a/src/metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
+++ b/src/metallic/kernels/repeat_kv_heads/repeat_kv_heads_test.rs
@@ -238,8 +238,9 @@ fn test_incremental_repeated_cache_matches_kernel() -> Result<(), MetalError> {
 
     let mut repeated_view = repeated_workspace.clone();
     repeated_view.dims = vec![batch * n_heads, seq, head_dim];
-    let repeated_slice = repeated_view.as_slice();
-    assert_eq!(repeated_slice, cpu_expected_k.as_slice());
+    let repeated_contiguous = ctx.materialize_contiguous_view(repeated_view)?;
+    ctx.synchronize();
+    assert_eq!(repeated_contiguous.as_slice(), cpu_expected_k.as_slice());
 
     Ok(())
 }

--- a/src/metallic/models/qwen25/qwen25_tests.rs
+++ b/src/metallic/models/qwen25/qwen25_tests.rs
@@ -319,7 +319,10 @@ fn test_repeat_kv_heads_incremental_workspace_reuse() -> Result<(), MetalError> 
         let reused = Qwen25::repeat_kv_heads(&workspace_history, group_size, batch, n_kv_heads, n_heads, kv_head_dim, &mut ctx)?;
 
         ctx.synchronize();
-        assert_eq!(reused.as_slice(), baseline.as_slice());
+        let baseline_contiguous = ctx.materialize_contiguous_view(baseline.clone())?;
+        let reused_contiguous = ctx.materialize_contiguous_view(reused.clone())?;
+        ctx.synchronize();
+        assert_eq!(reused_contiguous.as_slice(), baseline_contiguous.as_slice());
         previous_steps = steps;
     }
 


### PR DESCRIPTION
## Summary
- add per-layer reusable repeat-kv workspace in the Metal context so expanded KV heads persist across decode steps
- extend the repeat_kv_heads kernel/wrapper to accept destination offsets and incremental writes into preallocated buffers
- update Qwen25 KV repetition to reuse the workspace in both forward and step paths and add incremental regression coverage

## Testing
- Not run (Metal runtime unavailable in sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e2d49c02d0832699620b5934a15f84