### PR TITLE
Restore contiguous repeat kv workspace slicing

### DIFF
--- a/src/metallic/kernels/repeat_kv_heads/kernel.metal
+++ b/src/metallic/kernels/repeat_kv_heads/kernel.metal
@@ -16,9 +16,7 @@ kernel void repeat_kv_heads_kernel_##SUFFIX( \
     constant uint& seq [[buffer(6)]], \
     constant uint& head_dim [[buffer(7)]], \
     constant uint& cache_stride [[buffer(8)]], \
-    constant uint& dest_offset [[buffer(9)]], \
-    constant uint& output_stride [[buffer(10)]], \
-    constant uint& total_elements [[buffer(11)]], \
+    constant uint& total_elements [[buffer(9)]], \
     uint gid [[thread_position_in_grid]]) { \
     if (gid >= total_elements) { \
         return; \
@@ -32,7 +30,7 @@ kernel void repeat_kv_heads_kernel_##SUFFIX( \
     uint kv_head = h / group_size; \
     uint input_batch_head = b * n_kv_heads + kv_head; \
     uint input_index = ((input_batch_head * cache_stride) + seq_idx) * head_dim + dim_idx; \
-    uint output_index = ((batch_head_idx * output_stride) + dest_offset + seq_idx) * head_dim + dim_idx; \
+    uint output_index = ((batch_head_idx * cache_stride) + seq_idx) * head_dim + dim_idx; \
     output[output_index] = input[input_index]; \
 }
 

--- a/src/metallic/models/qwen25/qwen25_tests.rs
+++ b/src/metallic/models/qwen25/qwen25_tests.rs
@@ -145,7 +145,6 @@ fn test_kv_cache_correctness() -> Result<(), MetalError> {
             let repeated = ctx.call::<RepeatKvHeadsOp>((
                 canonical_view.clone(),
                 None,
-                0,
                 group_size as u32,
                 batch as u32,
                 n_kv_heads as u32,


### PR DESCRIPTION
## Summary
- slice the reserved repeat-kv workspace on the host so the Metal kernel receives the exact slice to fill
- simplify the repeat-kv Metal op/kernel to drop the dest offset/output stride parameters and rely on the host-provided view
- update the repeat-kv incremental reuse tests (kernel + Qwen25) for the slice-based API

## Testing
- not run (Metal/objc2 unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2e3e134008326a1d6ac8d1c0555be