### PR TITLE
Fix fused Q indexing for grouped query attention

### DIFF
--- a/src/metallic/kernels/fused_qkv/kernel.metal
+++ b/src/metallic/kernels/fused_qkv/kernel.metal
@@ -40,10 +40,8 @@ kernel void fused_qkv_kernel_##SUFFIX( \
         uint out_batch = tmp / seq; \
         uint b = out_batch / n_heads; \
         uint h = out_batch % n_heads; \
-        uint group_size = n_heads / n_kv_heads; \
-        uint kv_h = h / group_size; \
         uint row = b * seq + s; \
-        uint head_base = kv_h * head_dim; \
+        uint head_base = h * head_dim; \
         uint base_offset = head_base + feature; \
         uint src_idx = row * row_stride + base_offset; \
         SCALAR raw = fused[src_idx]; \


### PR DESCRIPTION
## Summary
- stop aliasing grouped query heads in the fused Q slice by indexing with the true head id
- keep the fused regression harness honest by comparing each Q head individually and ensuring the legacy path spans multiple heads

## Testing
- Not run (Metal runtime unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2fef791f48326a55da1fa418037f4