### PR TITLE
Add scaffolding for unified instrumentation module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ byteorder = "1.5"
 bytemuck = { version = "1.15", features = ["derive"] }
 approx = "0.5.1"
 serde_json = "1.0.145"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 ndarray-npy = "0.9.1"
 ndarray = "0.16.1"
 regex = "1.11.3"

--- a/src/metallic/instrument/config.rs
+++ b/src/metallic/instrument/config.rs
@@ -1,0 +1,91 @@
+//! Centralised instrumentation configuration handling.
+
+use std::env;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use tracing::Level;
+
+/// Errors that can occur while loading or initialising [`AppConfig`].
+#[derive(Debug, thiserror::Error)]
+pub enum AppConfigError {
+    /// The configuration attempted to initialise more than once.
+    #[error("app configuration already initialised")]
+    AlreadyInitialised,
+    /// A provided log level could not be parsed.
+    #[error("invalid log level '{value}'")]
+    InvalidLogLevel { value: String },
+    /// A provided boolean flag could not be parsed.
+    #[error("invalid boolean flag '{value}' for {name}")]
+    InvalidBoolean { name: &'static str, value: String },
+}
+
+/// Global application configuration for instrumentation and logging.
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    /// The minimum tracing level for application logs.
+    pub log_level: Level,
+    /// Optional path for persisting metrics as JSON lines.
+    pub metrics_jsonl_path: Option<PathBuf>,
+    /// Whether console metrics should be emitted.
+    pub enable_console_metrics: bool,
+}
+
+static APP_CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+impl AppConfig {
+    /// Load configuration from the process environment.
+    pub fn from_env() -> Result<Self, AppConfigError> {
+        let log_level = match env::var("METALLIC_LOG_LEVEL") {
+            Ok(value) => parse_level(&value)?,
+            Err(_) => Level::INFO,
+        };
+
+        let metrics_jsonl_path = env::var("METALLIC_METRICS_JSONL_PATH").ok().map(PathBuf::from);
+
+        let enable_console_metrics = match env::var("METALLIC_METRICS_CONSOLE") {
+            Ok(value) => parse_bool("METALLIC_METRICS_CONSOLE", &value)?,
+            Err(_) => false,
+        };
+
+        Ok(Self {
+            log_level,
+            metrics_jsonl_path,
+            enable_console_metrics,
+        })
+    }
+
+    /// Initialise the global configuration instance from environment variables.
+    pub fn initialise_from_env() -> Result<&'static Self, AppConfigError> {
+        let config = Self::from_env()?;
+        Self::initialise(config)
+    }
+
+    /// Store the provided configuration as the global instance.
+    pub fn initialise(config: AppConfig) -> Result<&'static Self, AppConfigError> {
+        APP_CONFIG.set(config).map_err(|_| AppConfigError::AlreadyInitialised)?;
+        Ok(APP_CONFIG.get().expect("configuration just initialised"))
+    }
+
+    /// Access the globally-initialised configuration.
+    pub fn global() -> &'static Self {
+        APP_CONFIG.get().expect("AppConfig not initialised")
+    }
+}
+
+fn parse_level(value: &str) -> Result<Level, AppConfigError> {
+    value
+        .parse::<Level>()
+        .map_err(|_| AppConfigError::InvalidLogLevel { value: value.to_string() })
+}
+
+fn parse_bool(name: &'static str, value: &str) -> Result<bool, AppConfigError> {
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(AppConfigError::InvalidBoolean {
+            name,
+            value: value.to_string(),
+        }),
+    }
+}

--- a/src/metallic/instrument/event.rs
+++ b/src/metallic/instrument/event.rs
@@ -1,0 +1,31 @@
+//! Canonical metric event definitions for the unified instrumentation system.
+
+use serde::{Deserialize, Serialize};
+
+/// Structured, type-safe metric events emitted by the instrumentation layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum MetricEvent {
+    /// Indicates that a GPU kernel has been dispatched and is now in-flight.
+    GpuKernelDispatched {
+        kernel_name: &'static str,
+        /// A unique name for this specific operation instance.
+        op_name: String,
+        thread_groups: (u32, u32, u32),
+    },
+    /// Generated when the GPU reports an operation has completed.
+    GpuOpCompleted {
+        op_name: String,
+        /// The backend that executed the operation (e.g., "Mlx", "Mps").
+        backend: String,
+        duration_us: u64,
+    },
+    /// Timing data for internal kernels invoked by frameworks such as MPS.
+    InternalKernelCompleted {
+        parent_op_name: String,
+        internal_kernel_name: String,
+        duration_us: u64,
+    },
+    /// Captures resource cache utilisation metrics.
+    ResourceCacheAccess { cache_key: String, hit: bool, bytes: u64 },
+}

--- a/src/metallic/instrument/exporters.rs
+++ b/src/metallic/instrument/exporters.rs
@@ -1,0 +1,74 @@
+//! Concrete metric exporter implementations.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::sync::Mutex;
+use std::sync::mpsc::Sender;
+
+use serde_json::to_string;
+
+use crate::metallic::instrument::recorder::{EnrichedMetricEvent, MetricExporter};
+
+/// Persist metrics as JSON lines to the provided file path.
+pub struct JsonlExporter {
+    writer: Mutex<BufWriter<File>>,
+}
+
+impl JsonlExporter {
+    /// Create a new exporter writing to `path`, appending if the file already exists.
+    pub fn new<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            writer: Mutex::new(BufWriter::new(file)),
+        })
+    }
+}
+
+impl MetricExporter for JsonlExporter {
+    fn export(&self, event: &EnrichedMetricEvent) {
+        if let Ok(serialised) = to_string(event) {
+            if let Ok(mut writer) = self.writer.lock() {
+                if let Err(error) = writeln!(writer, "{}", serialised) {
+                    tracing::error!(target: "instrument", ?error, "failed to write metric to jsonl");
+                }
+            }
+        }
+    }
+}
+
+/// Emit metrics to stdout for rapid prototyping and debugging.
+pub struct ConsoleExporter;
+
+impl ConsoleExporter {
+    /// Construct a new console exporter.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl MetricExporter for ConsoleExporter {
+    fn export(&self, event: &EnrichedMetricEvent) {
+        if let Ok(serialised) = to_string(event) {
+            println!("METRIC: {}", serialised);
+        }
+    }
+}
+
+/// Send metrics through an in-process channel.
+pub struct ChannelExporter {
+    sender: Sender<EnrichedMetricEvent>,
+}
+
+impl ChannelExporter {
+    /// Create a new exporter using the provided channel sender.
+    pub fn new(sender: Sender<EnrichedMetricEvent>) -> Self {
+        Self { sender }
+    }
+}
+
+impl MetricExporter for ChannelExporter {
+    fn export(&self, event: &EnrichedMetricEvent) {
+        let _ = self.sender.send(event.clone());
+    }
+}

--- a/src/metallic/instrument/macros.rs
+++ b/src/metallic/instrument/macros.rs
@@ -1,0 +1,17 @@
+//! Developer-facing macros for emitting structured metric events.
+
+/// Emit a `MetricEvent` through the tracing infrastructure.
+#[macro_export]
+macro_rules! record_metric {
+    ($event:expr) => {{
+        if tracing::enabled!(target: "metrics", level: tracing::Level::INFO) {
+            if let Ok(__metric_json) = serde_json::to_string(&$event) {
+                tracing::event!(
+                    target: "metrics",
+                    level: tracing::Level::INFO,
+                    metric = %__metric_json
+                );
+            }
+        }
+    }};
+}

--- a/src/metallic/instrument/mod.rs
+++ b/src/metallic/instrument/mod.rs
@@ -1,0 +1,12 @@
+//! Unified instrumentation module scaffolding the upcoming metrics system.
+
+pub mod config;
+pub mod event;
+pub mod exporters;
+pub mod macros;
+pub mod prelude;
+pub mod recorder;
+
+pub use config::{AppConfig, AppConfigError};
+pub use event::MetricEvent;
+pub use recorder::{EnrichedMetricEvent, MetricExporter, MetricsLayer};

--- a/src/metallic/instrument/prelude.rs
+++ b/src/metallic/instrument/prelude.rs
@@ -1,0 +1,7 @@
+//! Convenience re-exports for instrumentation consumers.
+
+pub use crate::metallic::instrument::config::{AppConfig, AppConfigError};
+pub use crate::metallic::instrument::event::MetricEvent;
+pub use crate::metallic::instrument::exporters::{ChannelExporter, ConsoleExporter, JsonlExporter};
+pub use crate::metallic::instrument::recorder::{EnrichedMetricEvent, MetricExporter, MetricsLayer};
+pub use crate::record_metric;

--- a/src/metallic/instrument/recorder.rs
+++ b/src/metallic/instrument/recorder.rs
@@ -1,0 +1,114 @@
+//! Tracing layer and exporter abstractions for metric collection.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tracing::{Event, Subscriber};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+use crate::metallic::instrument::event::MetricEvent;
+
+/// Metric events enriched with tracing context metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnrichedMetricEvent {
+    /// Timestamp captured at emission time.
+    pub timestamp: DateTime<Utc>,
+    /// Identifier of the active span, if any.
+    pub span_id: Option<u64>,
+    /// Identifier of the parent span.
+    pub parent_span_id: Option<u64>,
+    /// Name of the active span for ergonomic debugging.
+    pub span_name: Option<String>,
+    /// The structured metric event payload.
+    pub event: MetricEvent,
+}
+
+/// Exporter trait implemented by concrete sinks for metric events.
+pub trait MetricExporter: Send + Sync {
+    /// Export a single enriched metric event.
+    fn export(&self, event: &EnrichedMetricEvent);
+}
+
+/// Custom tracing layer responsible for routing metric events to exporters.
+#[derive(Clone)]
+pub struct MetricsLayer {
+    exporters: Arc<Vec<Box<dyn MetricExporter>>>,
+}
+
+impl MetricsLayer {
+    /// Construct a new metrics layer using the provided exporters.
+    pub fn new(exporters: Vec<Box<dyn MetricExporter>>) -> Self {
+        Self {
+            exporters: Arc::new(exporters),
+        }
+    }
+
+    fn dispatch(&self, event: &EnrichedMetricEvent) {
+        for exporter in self.exporters.iter() {
+            exporter.export(event);
+        }
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if event.metadata().target() != "metrics" {
+            return;
+        }
+
+        let metric_json = {
+            let mut visitor = MetricVisitor::default();
+            event.record(&mut visitor);
+            match visitor.metric_json {
+                Some(value) => value,
+                None => return,
+            }
+        };
+
+        let metric_event: MetricEvent = match serde_json::from_str(&metric_json) {
+            Ok(event) => event,
+            Err(error) => {
+                tracing::error!(
+                    target: "instrument",
+                    ?error,
+                    "failed to deserialize metric event"
+                );
+                return;
+            }
+        };
+
+        let span = ctx.lookup_current();
+        let enriched = EnrichedMetricEvent {
+            timestamp: Utc::now(),
+            span_id: span.map(|s| s.id().into_u64()),
+            parent_span_id: span.and_then(|s| s.parent()).map(|parent| parent.id().into_u64()),
+            span_name: span.and_then(|s| s.metadata().map(|meta| meta.name().to_string())),
+            event: metric_event,
+        };
+
+        self.dispatch(&enriched);
+    }
+}
+
+#[derive(Default)]
+struct MetricVisitor {
+    metric_json: Option<String>,
+}
+
+impl tracing::field::Visit for MetricVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "metric" {
+            self.metric_json = Some(format!("{:?}", value));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "metric" {
+            self.metric_json = Some(value.to_string());
+        }
+    }
+}

--- a/src/metallic/mod.rs
+++ b/src/metallic/mod.rs
@@ -11,6 +11,7 @@ pub mod cacheable_sdpa;
 pub mod context;
 pub mod encoder;
 pub mod error;
+pub mod instrument;
 pub mod instrumentation;
 pub mod metrics;
 pub mod operation;


### PR DESCRIPTION
## Summary
- add a new `metallic::instrument` module scaffolding the unified metrics system
- implement configuration loading, canonical metric events, tracing layer, and exporter implementations
- provide developer macros and a prelude to ease adoption in later migrations

## Testing
- cargo fmt


------
https://chatgpt.com/codex/tasks/task_e_68e30ba8dc84832689bc680951e71710