### PR TITLE
Add instrumentation unit tests for configuration and exporters

### DIFF
--- a/src/metallic/instrument/environment.rs
+++ b/src/metallic/instrument/environment.rs
@@ -1,0 +1,123 @@
+//! Process environment helpers for instrumentation configuration.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Namespaced environment variable identifiers used by instrumentation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EnvVar {
+    /// Environment variables specific to the instrumentation pipeline.
+    Instrument(InstrumentEnvVar),
+}
+
+/// Instrumentation-specific environment variables.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InstrumentEnvVar {
+    /// Controls the global log level for the instrumentation pipeline.
+    LogLevel,
+    /// Path where metrics should be persisted as JSONL.
+    MetricsJsonlPath,
+    /// Enables console metrics emission when set to a truthy value.
+    MetricsConsole,
+}
+
+impl From<InstrumentEnvVar> for EnvVar {
+    fn from(value: InstrumentEnvVar) -> Self {
+        Self::Instrument(value)
+    }
+}
+
+impl EnvVar {
+    /// Retrieve the canonical environment variable key for the identifier.
+    pub const fn key(self) -> &'static str {
+        match self {
+            EnvVar::Instrument(inner) => inner.key(),
+        }
+    }
+}
+
+impl InstrumentEnvVar {
+    /// Obtain the canonical environment variable key for the identifier.
+    pub const fn key(self) -> &'static str {
+        match self {
+            InstrumentEnvVar::LogLevel => "METALLIC_LOG_LEVEL",
+            InstrumentEnvVar::MetricsJsonlPath => "METALLIC_METRICS_JSONL_PATH",
+            InstrumentEnvVar::MetricsConsole => "METALLIC_METRICS_CONSOLE",
+        }
+    }
+
+    /// Convert into the unscoped [`EnvVar`] variant.
+    pub const fn into_env(self) -> EnvVar {
+        EnvVar::Instrument(self)
+    }
+}
+
+/// Guard object that restores the previous environment state upon drop.
+pub struct EnvVarGuard {
+    var: EnvVar,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    /// Set the provided environment variable for the duration of the guard.
+    pub fn set(var: impl Into<EnvVar>, value: &str) -> Self {
+        let var = var.into();
+        let previous = Environment::get(var);
+        Environment::set(var, value);
+        Self { var, previous }
+    }
+
+    /// Unset the provided environment variable for the duration of the guard.
+    pub fn unset(var: impl Into<EnvVar>) -> Self {
+        let var = var.into();
+        let previous = Environment::get(var);
+        Environment::remove(var);
+        Self { var, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            Environment::set(self.var, previous);
+        } else {
+            Environment::remove(self.var);
+        }
+    }
+}
+
+/// Process environment facade that centralises access and synchronisation.
+pub struct Environment;
+
+impl Environment {
+    /// Acquire the global environment mutex, ensuring serialised mutations.
+    pub fn lock() -> MutexGuard<'static, ()> {
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().expect("environment mutex poisoned")
+    }
+
+    /// Read the environment variable as a UTF-8 string if present.
+    pub fn get(var: impl Into<EnvVar>) -> Option<String> {
+        let var = var.into();
+        std::env::var(var.key()).ok()
+    }
+
+    /// Set the environment variable using the provided UTF-8 value.
+    #[allow(unused_unsafe)]
+    pub fn set(var: impl Into<EnvVar>, value: &str) {
+        let var = var.into();
+        // SAFETY: Environment mutations are synchronised via [`Environment::lock`].
+        unsafe {
+            std::env::set_var(var.key(), value);
+        }
+    }
+
+    /// Remove the environment variable from the process environment.
+    #[allow(unused_unsafe)]
+    pub fn remove(var: impl Into<EnvVar>) {
+        let var = var.into();
+        // SAFETY: Environment mutations are synchronised via [`Environment::lock`].
+        unsafe {
+            std::env::remove_var(var.key());
+        }
+    }
+}

--- a/src/metallic/instrument/macros.rs
+++ b/src/metallic/instrument/macros.rs
@@ -1,16 +1,14 @@
 //! Developer-facing macros for emitting structured metric events.
 
-use tracing::Level;
-
 /// Emit a `MetricEvent` through the tracing infrastructure.
 #[macro_export]
 macro_rules! record_metric {
     ($event:expr) => {{
-        if tracing::enabled!(target: "metrics", Level::INFO) {
+        if tracing::enabled!(target: "metrics", level: tracing::Level::INFO) {
             if let Ok(__metric_json) = serde_json::to_string(&$event) {
                 tracing::event!(
                     target: "metrics",
-                    Level::INFO,
+                    level: tracing::Level::INFO,
                     metric = %__metric_json
                 );
             }

--- a/src/metallic/instrument/macros.rs
+++ b/src/metallic/instrument/macros.rs
@@ -1,14 +1,16 @@
 //! Developer-facing macros for emitting structured metric events.
 
+use tracing::Level;
+
 /// Emit a `MetricEvent` through the tracing infrastructure.
 #[macro_export]
 macro_rules! record_metric {
     ($event:expr) => {{
-        if tracing::enabled!(target: "metrics", level: tracing::Level::INFO) {
+        if tracing::enabled!(target: "metrics", Level::INFO) {
             if let Ok(__metric_json) = serde_json::to_string(&$event) {
                 tracing::event!(
                     target: "metrics",
-                    level: tracing::Level::INFO,
+                    level: Level::INFO,
                     metric = %__metric_json
                 );
             }

--- a/src/metallic/instrument/macros.rs
+++ b/src/metallic/instrument/macros.rs
@@ -10,7 +10,7 @@ macro_rules! record_metric {
             if let Ok(__metric_json) = serde_json::to_string(&$event) {
                 tracing::event!(
                     target: "metrics",
-                    level: Level::INFO,
+                    Level::INFO,
                     metric = %__metric_json
                 );
             }

--- a/src/metallic/instrument/macros.rs
+++ b/src/metallic/instrument/macros.rs
@@ -4,11 +4,11 @@
 #[macro_export]
 macro_rules! record_metric {
     ($event:expr) => {{
-        if tracing::enabled!(target: "metrics", level: tracing::Level::INFO) {
+        if tracing::enabled!(target: "metrics", tracing::Level::INFO) {
             if let Ok(__metric_json) = serde_json::to_string(&$event) {
                 tracing::event!(
                     target: "metrics",
-                    level: tracing::Level::INFO,
+                    tracing::Level::INFO,
                     metric = %__metric_json
                 );
             }

--- a/src/metallic/instrument/mod.rs
+++ b/src/metallic/instrument/mod.rs
@@ -10,3 +10,6 @@ pub mod recorder;
 pub use config::{AppConfig, AppConfigError};
 pub use event::MetricEvent;
 pub use recorder::{EnrichedMetricEvent, MetricExporter, MetricsLayer};
+
+#[cfg(test)]
+mod tests;

--- a/src/metallic/instrument/mod.rs
+++ b/src/metallic/instrument/mod.rs
@@ -1,6 +1,7 @@
 //! Unified instrumentation module scaffolding the upcoming metrics system.
 
 pub mod config;
+pub mod environment;
 pub mod event;
 pub mod exporters;
 pub mod macros;

--- a/src/metallic/instrument/prelude.rs
+++ b/src/metallic/instrument/prelude.rs
@@ -5,3 +5,8 @@ pub use crate::metallic::instrument::event::MetricEvent;
 pub use crate::metallic::instrument::exporters::{ChannelExporter, ConsoleExporter, JsonlExporter};
 pub use crate::metallic::instrument::recorder::{EnrichedMetricEvent, MetricExporter, MetricsLayer};
 pub use crate::record_metric;
+
+pub use chrono::{DateTime, Utc};
+pub use serde_json;
+pub use tracing::{Level, info, info_span, subscriber};
+pub use tracing_subscriber::{self, layer::SubscriberExt};

--- a/src/metallic/instrument/prelude.rs
+++ b/src/metallic/instrument/prelude.rs
@@ -1,6 +1,7 @@
 //! Convenience re-exports for instrumentation consumers.
 
 pub use crate::metallic::instrument::config::{AppConfig, AppConfigError};
+pub use crate::metallic::instrument::environment::{EnvVar, EnvVarGuard, Environment, InstrumentEnvVar};
 pub use crate::metallic::instrument::event::MetricEvent;
 pub use crate::metallic::instrument::exporters::{ChannelExporter, ConsoleExporter, JsonlExporter};
 pub use crate::metallic::instrument::recorder::{EnrichedMetricEvent, MetricExporter, MetricsLayer};

--- a/src/metallic/instrument/tests/config.rs
+++ b/src/metallic/instrument/tests/config.rs
@@ -1,0 +1,60 @@
+use crate::metallic::instrument::prelude::*;
+
+use super::{EnvVarGuard, env_mutex};
+
+use tracing::Level;
+
+#[test]
+fn app_config_parses_environment_and_initialises() {
+    let _lock = env_mutex().lock().expect("env mutex poisoned");
+    let _log_level = EnvVarGuard::set("METALLIC_LOG_LEVEL", "debug");
+    let _jsonl_path = EnvVarGuard::set("METALLIC_METRICS_JSONL_PATH", "/tmp/metrics.jsonl");
+    let _console = EnvVarGuard::set("METALLIC_METRICS_CONSOLE", "true");
+
+    let config = AppConfig::from_env().expect("configuration should parse");
+    assert_eq!(config.log_level, Level::DEBUG);
+    assert_eq!(
+        config.metrics_jsonl_path.as_deref(),
+        Some(std::path::Path::new("/tmp/metrics.jsonl"))
+    );
+    assert!(config.enable_console_metrics);
+
+    let initialised = AppConfig::initialise(config.clone()).expect("initialise should succeed once");
+    assert_eq!(initialised.log_level, Level::DEBUG);
+    assert_eq!(initialised.metrics_jsonl_path, config.metrics_jsonl_path);
+    assert!(initialised.enable_console_metrics);
+
+    match AppConfig::initialise(config) {
+        Err(AppConfigError::AlreadyInitialised) => {}
+        other => panic!("expected already initialised error, got {other:?}"),
+    }
+}
+
+#[test]
+fn app_config_rejects_invalid_log_level() {
+    let _lock = env_mutex().lock().expect("env mutex poisoned");
+    let _log_level = EnvVarGuard::set("METALLIC_LOG_LEVEL", "verbose");
+    let _jsonl_path = EnvVarGuard::unset("METALLIC_METRICS_JSONL_PATH");
+    let _console = EnvVarGuard::unset("METALLIC_METRICS_CONSOLE");
+
+    match AppConfig::from_env() {
+        Err(AppConfigError::InvalidLogLevel { value }) => assert_eq!(value, "verbose"),
+        other => panic!("expected invalid log level error, got {other:?}"),
+    }
+}
+
+#[test]
+fn app_config_rejects_invalid_console_flag() {
+    let _lock = env_mutex().lock().expect("env mutex poisoned");
+    let _console = EnvVarGuard::set("METALLIC_METRICS_CONSOLE", "maybe");
+    let _log_level = EnvVarGuard::unset("METALLIC_LOG_LEVEL");
+    let _jsonl_path = EnvVarGuard::unset("METALLIC_METRICS_JSONL_PATH");
+
+    match AppConfig::from_env() {
+        Err(AppConfigError::InvalidBoolean { name, value }) => {
+            assert_eq!(name, "METALLIC_METRICS_CONSOLE");
+            assert_eq!(value, "maybe");
+        }
+        other => panic!("expected invalid boolean error, got {other:?}"),
+    }
+}

--- a/src/metallic/instrument/tests/config.rs
+++ b/src/metallic/instrument/tests/config.rs
@@ -1,13 +1,11 @@
 use crate::metallic::instrument::prelude::*;
 
-use super::{EnvVarGuard, env_mutex};
-
 #[test]
 fn app_config_parses_environment_and_initialises() {
-    let _lock = env_mutex().lock().expect("env mutex poisoned");
-    let _log_level = EnvVarGuard::set("METALLIC_LOG_LEVEL", "debug");
-    let _jsonl_path = EnvVarGuard::set("METALLIC_METRICS_JSONL_PATH", "/tmp/metrics.jsonl");
-    let _console = EnvVarGuard::set("METALLIC_METRICS_CONSOLE", "true");
+    let _lock = Environment::lock();
+    let _log_level = EnvVarGuard::set(InstrumentEnvVar::LogLevel, "debug");
+    let _jsonl_path = EnvVarGuard::set(InstrumentEnvVar::MetricsJsonlPath, "/tmp/metrics.jsonl");
+    let _console = EnvVarGuard::set(InstrumentEnvVar::MetricsConsole, "true");
 
     let config = AppConfig::from_env().expect("configuration should parse");
     assert_eq!(config.log_level, Level::DEBUG);
@@ -30,10 +28,10 @@ fn app_config_parses_environment_and_initialises() {
 
 #[test]
 fn app_config_rejects_invalid_log_level() {
-    let _lock = env_mutex().lock().expect("env mutex poisoned");
-    let _log_level = EnvVarGuard::set("METALLIC_LOG_LEVEL", "verbose");
-    let _jsonl_path = EnvVarGuard::unset("METALLIC_METRICS_JSONL_PATH");
-    let _console = EnvVarGuard::unset("METALLIC_METRICS_CONSOLE");
+    let _lock = Environment::lock();
+    let _log_level = EnvVarGuard::set(InstrumentEnvVar::LogLevel, "verbose");
+    let _jsonl_path = EnvVarGuard::unset(InstrumentEnvVar::MetricsJsonlPath);
+    let _console = EnvVarGuard::unset(InstrumentEnvVar::MetricsConsole);
 
     match AppConfig::from_env() {
         Err(AppConfigError::InvalidLogLevel { value }) => assert_eq!(value, "verbose"),
@@ -43,14 +41,14 @@ fn app_config_rejects_invalid_log_level() {
 
 #[test]
 fn app_config_rejects_invalid_console_flag() {
-    let _lock = env_mutex().lock().expect("env mutex poisoned");
-    let _console = EnvVarGuard::set("METALLIC_METRICS_CONSOLE", "maybe");
-    let _log_level = EnvVarGuard::unset("METALLIC_LOG_LEVEL");
-    let _jsonl_path = EnvVarGuard::unset("METALLIC_METRICS_JSONL_PATH");
+    let _lock = Environment::lock();
+    let _console = EnvVarGuard::set(InstrumentEnvVar::MetricsConsole, "maybe");
+    let _log_level = EnvVarGuard::unset(InstrumentEnvVar::LogLevel);
+    let _jsonl_path = EnvVarGuard::unset(InstrumentEnvVar::MetricsJsonlPath);
 
     match AppConfig::from_env() {
         Err(AppConfigError::InvalidBoolean { name, value }) => {
-            assert_eq!(name, "METALLIC_METRICS_CONSOLE");
+            assert_eq!(name, InstrumentEnvVar::MetricsConsole.key());
             assert_eq!(value, "maybe");
         }
         other => panic!("expected invalid boolean error, got {other:?}"),

--- a/src/metallic/instrument/tests/config.rs
+++ b/src/metallic/instrument/tests/config.rs
@@ -2,8 +2,6 @@ use crate::metallic::instrument::prelude::*;
 
 use super::{EnvVarGuard, env_mutex};
 
-use tracing::Level;
-
 #[test]
 fn app_config_parses_environment_and_initialises() {
     let _lock = env_mutex().lock().expect("env mutex poisoned");

--- a/src/metallic/instrument/tests/exporters.rs
+++ b/src/metallic/instrument/tests/exporters.rs
@@ -3,8 +3,6 @@ use crate::metallic::instrument::prelude::*;
 use std::sync::mpsc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use chrono::Utc;
-
 #[test]
 fn jsonl_exporter_writes_serialised_metrics() {
     let mut path = std::env::temp_dir();

--- a/src/metallic/instrument/tests/exporters.rs
+++ b/src/metallic/instrument/tests/exporters.rs
@@ -1,0 +1,86 @@
+use crate::metallic::instrument::prelude::*;
+
+use std::sync::mpsc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::Utc;
+
+#[test]
+fn jsonl_exporter_writes_serialised_metrics() {
+    let mut path = std::env::temp_dir();
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    path.push(format!("metallic_metrics_test_{}.jsonl", unique));
+
+    let event = EnrichedMetricEvent {
+        timestamp: Utc::now(),
+        span_id: Some(42),
+        parent_span_id: Some(24),
+        span_name: Some("jsonl_span".to_string()),
+        event: MetricEvent::GpuKernelDispatched {
+            kernel_name: "jsonl_kernel".to_string(),
+            op_name: "jsonl_op".to_string(),
+            thread_groups: (4, 2, 1),
+        },
+    };
+
+    {
+        let exporter = JsonlExporter::new(&path).expect("jsonl exporter should open file");
+        exporter.export(&event);
+    }
+
+    let contents = std::fs::read_to_string(&path).expect("jsonl exporter should write file");
+    let expected = serde_json::to_string(&event).expect("event should serialise");
+    assert_eq!(contents.trim_end_matches('\n'), expected);
+
+    std::fs::remove_file(&path).expect("temporary jsonl file should be removable");
+}
+
+#[test]
+fn channel_exporter_clones_events() {
+    let (sender, receiver) = mpsc::channel();
+    let exporter = ChannelExporter::new(sender);
+
+    let mut event = EnrichedMetricEvent {
+        timestamp: Utc::now(),
+        span_id: Some(7),
+        parent_span_id: Some(3),
+        span_name: Some("channel".to_string()),
+        event: MetricEvent::GpuKernelDispatched {
+            kernel_name: "channel_kernel".to_string(),
+            op_name: "channel_op".to_string(),
+            thread_groups: (1, 1, 1),
+        },
+    };
+
+    exporter.export(&event);
+
+    event.span_name = Some("mutated".to_string());
+    event.event = MetricEvent::GpuOpCompleted {
+        op_name: "channel_op".to_string(),
+        backend: "TestBackend".to_string(),
+        duration_us: 123,
+    };
+
+    let received = receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("channel should receive cloned event");
+
+    assert_eq!(received.span_name.as_deref(), Some("channel"));
+    assert_ne!(received.span_name, event.span_name);
+
+    match received.event {
+        MetricEvent::GpuKernelDispatched {
+            kernel_name,
+            op_name,
+            thread_groups,
+        } => {
+            assert_eq!(kernel_name, "channel_kernel");
+            assert_eq!(op_name, "channel_op");
+            assert_eq!(thread_groups, (1, 1, 1));
+        }
+        other => panic!("expected cloned gpu dispatch event, got {other:?}"),
+    }
+}

--- a/src/metallic/instrument/tests/layer.rs
+++ b/src/metallic/instrument/tests/layer.rs
@@ -1,0 +1,69 @@
+use crate::metallic::instrument::prelude::*;
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use tracing::{info, info_span};
+use tracing_subscriber::layer::SubscriberExt;
+
+#[test]
+fn metrics_layer_enriches_span_context() {
+    let (sender, receiver) = mpsc::channel();
+    let exporters: Vec<Box<dyn MetricExporter>> = vec![Box::new(ChannelExporter::new(sender))];
+    let layer = MetricsLayer::new(exporters);
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    let metric_event = MetricEvent::GpuKernelDispatched {
+        kernel_name: "matmul_kernel".to_string(),
+        op_name: "matmul_op".to_string(),
+        thread_groups: (8, 8, 1),
+    };
+
+    let (parent_id, child_id) = tracing::subscriber::with_default(subscriber, || {
+        let parent_span = info_span!("parent_span");
+        let parent_id = parent_span.id().map(|id| id.into_u64()).expect("parent span should be active");
+        let _parent_guard = parent_span.enter();
+
+        let child_span = info_span!("kernel_span");
+        let child_id = child_span.id().map(|id| id.into_u64()).expect("child span should be active");
+        let _child_guard = child_span.enter();
+
+        record_metric!(metric_event.clone());
+        (Some(parent_id), Some(child_id))
+    });
+
+    let enriched = receiver.recv_timeout(Duration::from_secs(1)).expect("metric should be dispatched");
+
+    assert_eq!(enriched.span_id, child_id);
+    assert_eq!(enriched.parent_span_id, parent_id);
+    assert_eq!(enriched.span_name.as_deref(), Some("kernel_span"));
+
+    match enriched.event {
+        MetricEvent::GpuKernelDispatched {
+            ref kernel_name,
+            ref op_name,
+            thread_groups,
+        } => {
+            assert_eq!(kernel_name, "matmul_kernel");
+            assert_eq!(op_name, "matmul_op");
+            assert_eq!(thread_groups, (8, 8, 1));
+        }
+        other => panic!("expected gpu dispatch metric, got {other:?}"),
+    }
+}
+
+#[test]
+fn metrics_layer_ignores_non_metric_events() {
+    let (sender, receiver) = mpsc::channel();
+    let exporters: Vec<Box<dyn MetricExporter>> = vec![Box::new(ChannelExporter::new(sender))];
+    let layer = MetricsLayer::new(exporters);
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let span = info_span!("non_metric_span");
+        let _guard = span.enter();
+        info!("non-metric event should be ignored");
+    });
+
+    assert!(receiver.try_recv().is_err(), "channel should remain empty");
+}

--- a/src/metallic/instrument/tests/layer.rs
+++ b/src/metallic/instrument/tests/layer.rs
@@ -3,9 +3,6 @@ use crate::metallic::instrument::prelude::*;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use tracing::{info, info_span};
-use tracing_subscriber::layer::SubscriberExt;
-
 #[test]
 fn metrics_layer_enriches_span_context() {
     let (sender, receiver) = mpsc::channel();
@@ -19,7 +16,7 @@ fn metrics_layer_enriches_span_context() {
         thread_groups: (8, 8, 1),
     };
 
-    let (parent_id, child_id) = tracing::subscriber::with_default(subscriber, || {
+    let (parent_id, child_id) = subscriber::with_default(subscriber, || {
         let parent_span = info_span!("parent_span");
         let parent_id = parent_span.id().map(|id| id.into_u64()).expect("parent span should be active");
         let _parent_guard = parent_span.enter();
@@ -59,7 +56,7 @@ fn metrics_layer_ignores_non_metric_events() {
     let layer = MetricsLayer::new(exporters);
     let subscriber = tracing_subscriber::registry().with(layer);
 
-    tracing::subscriber::with_default(subscriber, || {
+    subscriber::with_default(subscriber, || {
         let span = info_span!("non_metric_span");
         let _guard = span.enter();
         info!("non-metric event should be ignored");

--- a/src/metallic/instrument/tests/mod.rs
+++ b/src/metallic/instrument/tests/mod.rs
@@ -1,41 +1,5 @@
 #![cfg(test)]
 
-use std::sync::{Mutex, OnceLock};
-
 mod config;
 mod exporters;
 mod layer;
-
-pub(super) fn env_mutex() -> &'static Mutex<()> {
-    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-    ENV_MUTEX.get_or_init(|| Mutex::new(()))
-}
-
-pub(super) struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<String>,
-}
-
-impl EnvVarGuard {
-    pub(super) fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var(key).ok();
-        std::env::set_var(key, value);
-        Self { key, previous }
-    }
-
-    pub(super) fn unset(key: &'static str) -> Self {
-        let previous = std::env::var(key).ok();
-        std::env::remove_var(key);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(previous) = &self.previous {
-            std::env::set_var(self.key, previous);
-        } else {
-            std::env::remove_var(self.key);
-        }
-    }
-}

--- a/src/metallic/instrument/tests/mod.rs
+++ b/src/metallic/instrument/tests/mod.rs
@@ -1,0 +1,41 @@
+#![cfg(test)]
+
+use std::sync::{Mutex, OnceLock};
+
+mod config;
+mod exporters;
+mod layer;
+
+pub(super) fn env_mutex() -> &'static Mutex<()> {
+    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+pub(super) struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    pub(super) fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    pub(super) fn unset(key: &'static str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}

--- a/src/metallic/instrument/tests/mod.rs
+++ b/src/metallic/instrument/tests/mod.rs
@@ -6,23 +6,6 @@ mod config;
 mod exporters;
 mod layer;
 
-fn set_env_var(key: &str, value: &str) {
-    // Safety: the standard library marks these interfaces as unsafe for our
-    // target configuration, but the inputs we provide are constant ASCII
-    // strings, ensuring they are well-formed and null-terminated as required.
-    unsafe {
-        std::env::set_var(key, value);
-    }
-}
-
-fn remove_env_var(key: &str) {
-    // Safety: removing a variable with a constant ASCII key is always valid
-    // for the platform configuration used in tests.
-    unsafe {
-        std::env::remove_var(key);
-    }
-}
-
 pub(super) fn env_mutex() -> &'static Mutex<()> {
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
     ENV_MUTEX.get_or_init(|| Mutex::new(()))
@@ -36,13 +19,13 @@ pub(super) struct EnvVarGuard {
 impl EnvVarGuard {
     pub(super) fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
-        set_env_var(key, value);
+        std::env::set_var(key, value);
         Self { key, previous }
     }
 
     pub(super) fn unset(key: &'static str) -> Self {
         let previous = std::env::var(key).ok();
-        remove_env_var(key);
+        std::env::remove_var(key);
         Self { key, previous }
     }
 }
@@ -50,9 +33,9 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         if let Some(previous) = &self.previous {
-            set_env_var(self.key, previous);
+            std::env::set_var(self.key, previous);
         } else {
-            remove_env_var(self.key);
+            std::env::remove_var(self.key);
         }
     }
 }

--- a/src/metallic/instrument/tests/mod.rs
+++ b/src/metallic/instrument/tests/mod.rs
@@ -6,6 +6,23 @@ mod config;
 mod exporters;
 mod layer;
 
+fn set_env_var(key: &str, value: &str) {
+    // Safety: the standard library marks these interfaces as unsafe for our
+    // target configuration, but the inputs we provide are constant ASCII
+    // strings, ensuring they are well-formed and null-terminated as required.
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_env_var(key: &str) {
+    // Safety: removing a variable with a constant ASCII key is always valid
+    // for the platform configuration used in tests.
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
 pub(super) fn env_mutex() -> &'static Mutex<()> {
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
     ENV_MUTEX.get_or_init(|| Mutex::new(()))
@@ -19,13 +36,13 @@ pub(super) struct EnvVarGuard {
 impl EnvVarGuard {
     pub(super) fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
-        std::env::set_var(key, value);
+        set_env_var(key, value);
         Self { key, previous }
     }
 
     pub(super) fn unset(key: &'static str) -> Self {
         let previous = std::env::var(key).ok();
-        std::env::remove_var(key);
+        remove_env_var(key);
         Self { key, previous }
     }
 }
@@ -33,9 +50,9 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         if let Some(previous) = &self.previous {
-            std::env::set_var(self.key, previous);
+            set_env_var(self.key, previous);
         } else {
-            std::env::remove_var(self.key);
+            remove_env_var(self.key);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a cfg(test) instrumentation tests module with shared environment helpers
- cover AppConfig parsing, initialisation, and error paths via environment mutations
- verify MetricsLayer enrichment plus exporter behaviours for channel and JSONL sinks

## Testing
- cargo fmt
- _not run_: cargo test (requires Apple Metal environment)


------
https://chatgpt.com/codex/tasks/task_e_68e310c93af4832685188a0ff0138664